### PR TITLE
add logging output to kubetest

### DIFF
--- a/examples/test_configmap.py
+++ b/examples/test_configmap.py
@@ -1,7 +1,6 @@
 """An example of using kubetest to manage a configmap."""
 
 import os
-import time
 
 
 def test_configmap(kube):
@@ -13,36 +12,12 @@ def test_configmap(kube):
     )
 
     cm = kube.load_configmap(f)
-    print('---------- loaded -------------')
-    print(vars(cm))
 
     kube.create(cm)
-    print('---------- created -------------')
-    print(vars(cm))
 
-    print('---------- waiting ----------')
-    start = time.time()
     cm.wait_until_ready(timeout=10)
-    end = time.time()
-    print('---------- done ({}s) ----------'.format(end - start))
-
     cm.refresh()
-    print('---------- refreshed -------------')
-    print(vars(cm))
 
-    status = kube.delete(cm)
-    print('---------- deleted -------------')
-    print(vars(cm))
+    kube.delete(cm)
 
-    print('---------- status -------------')
-    print(status)
-
-    print('---------- waiting ----------')
-    start = time.time()
     cm.wait_until_deleted(timeout=20)
-    end = time.time()
-    print('---------- done ({}s) ----------'.format(end - start))
-
-    # assert false to fail the test - this allows us to get the
-    # captured stdout (e.g. the print statements above)
-    assert False

--- a/examples/test_deployment.py
+++ b/examples/test_deployment.py
@@ -1,7 +1,6 @@
 """An example of using kubetest to manage a deployment."""
 
 import os
-import time
 
 
 def test_deployment(kube):
@@ -13,51 +12,17 @@ def test_deployment(kube):
     )
 
     d = kube.load_deployment(f)
-    print('---------- loaded -------------')
-    print(vars(d))
 
     kube.create(d)
-    print('---------- created -------------')
-    print(vars(d))
 
-    print('---------- waiting ----------')
-    start = time.time()
-    d.wait_until_ready(timeout=10)
-    end = time.time()
-    print('---------- done ({}s) ----------'.format(end - start))
-
+    d.wait_until_ready(timeout=20)
     d.refresh()
-    print('---------- refreshed -------------')
-    print(vars(d))
-
-    x = d.status()
-    print('---------- status -------------')
-    print(x)
 
     pods = d.get_pods()
-    print('---------- pods -------------')
-    # print(pods)
+    assert len(pods) == 1
+
     p = pods[0]
-
-    print('---------- waiting ----------')
-    start = time.time()
     p.wait_until_ready(timeout=10)
-    end = time.time()
-    print('---------- done ({}s) ----------'.format(end - start))
 
-    status = kube.delete(d)
-    print('---------- deleted -------------')
-    print(vars(d))
-
-    print('---------- status -------------')
-    print(status)
-
-    print('---------- waiting ----------')
-    start = time.time()
+    kube.delete(d)
     d.wait_until_deleted(timeout=20)
-    end = time.time()
-    print('---------- done ({}s) ----------'.format(end - start))
-
-    # assert false to fail the test - this allows us to get the
-    # captured stdout (e.g. the print statements above)
-    assert False

--- a/examples/test_service.py
+++ b/examples/test_service.py
@@ -1,7 +1,6 @@
 """An example of using kubetest to manage a service."""
 
 import os
-import time
 
 
 def test_service(kube):
@@ -19,52 +18,19 @@ def test_service(kube):
     )
 
     svc = kube.load_service(f)
-    print('---------- loaded svc -------------')
-    print(vars(svc))
-
     dep = kube.load_deployment(d)
 
     kube.create(svc)
-    print('---------- created -------------')
-    print(vars(svc))
-
     kube.create(dep)
 
-    print('---------- waiting ----------')
-    start = time.time()
     svc.wait_until_ready(timeout=10)
-    end = time.time()
-    print('---------- done ({}s) ----------'.format(end - start))
-
     svc.refresh()
-    print('---------- refreshed -------------')
-    print(vars(svc))
-
-    x = svc.status()
-    print('---------- status -------------')
-    print(x)
 
     endpoints = svc.get_endpoints()
-    print('---------- endpoints -------------')
-    print(endpoints)
+    assert len(endpoints) == 1
 
-    x = svc.status()
-    print('---------- status -------------')
-    print(x)
+    kube.delete(svc)
+    kube.delete(dep)
 
-    status = kube.delete(svc)
-    print('---------- deleted -------------')
-    print(vars(svc))
-
-    print('---------- status -------------')
-    print(status)
-
-    print('---------- waiting ----------')
-    start = time.time()
     svc.wait_until_deleted(timeout=20)
-    end = time.time()
-    print('---------- done ({}s) ----------'.format(end - start))
-
-    # assert false to fail the test - this allows us to get the
-    # captured stdout (e.g. the print statements above)
-    assert False
+    svc.wait_until_deleted(timeout=20)

--- a/kubetest/client.py
+++ b/kubetest/client.py
@@ -1,8 +1,12 @@
 """Test client provided by kubetest for managing kubernetes objects."""
 
+import logging
+
 from kubernetes import client
 
 from kubetest import objects
+
+log = logging.getLogger('kubetest')
 
 
 class TestClient:
@@ -19,6 +23,7 @@ class TestClient:
         so the client is only initialized when the test actually requests
         it.
         """
+        log.info('creating namespace: %s', self.namespace)
         self.create_namespace(self.namespace)
 
     def teardown(self):
@@ -28,6 +33,7 @@ class TestClient:
         cleaned up after a test case has been run. This is called in the
         pytest runtest teardown hook.
         """
+        log.info('deleting namespace: %s', self.namespace)
         self.delete_namespace(self.namespace)
 
     # ****** Manifest Loaders ******
@@ -47,6 +53,7 @@ class TestClient:
         Returns:
             Configmap: The ConfigMap for the specified manifest.
         """
+        log.info('loading configmap from path: %s', path)
         configmap = objects.Configmap.load(path)
         if set_namespace:
             configmap.namespace = self.namespace
@@ -67,6 +74,7 @@ class TestClient:
         Returns:
             Deployment: The Deployment for the specified manifest.
         """
+        log.info('loading deployment from path: %s', path)
         deployment = objects.Deployment.load(path)
         if set_namespace:
             deployment.namespace = self.namespace
@@ -87,6 +95,7 @@ class TestClient:
         Returns:
             Pod: The Pod for the specified manifest.
         """
+        log.info('loading pod from path: %s', path)
         pod = objects.Pod.load(path)
         if set_namespace:
             pod.namespace = self.namespace
@@ -107,6 +116,7 @@ class TestClient:
         Returns:
             Service: The Service for the specified manifest.
         """
+        log.info('loading service from path: %s', path)
         service = objects.Service.load(path)
         if set_namespace:
             service.namespace = self.namespace

--- a/kubetest/manager.py
+++ b/kubetest/manager.py
@@ -1,6 +1,10 @@
 """Kubetest manager for test client instances and namespace management."""
 
+import logging
+
 from kubetest import client, utils
+
+log = logging.getLogger('kubetest')
 
 
 class KubetestManager:
@@ -31,6 +35,8 @@ class KubetestManager:
             TestClient: A test client configured for the named test case.
         """
         ns = utils.new_namespace(test_name)
+
+        log.info('creating test client for %s with namespace %s', node_id, ns)
         test_client = client.TestClient(ns)
 
         # Add the test client to the manager's client dictionary for tracking.

--- a/kubetest/objects.py
+++ b/kubetest/objects.py
@@ -1,6 +1,7 @@
 """Kubetest wrappers for Kubernetes API Objects."""
 
 import abc
+import logging
 import time
 
 import yaml
@@ -9,6 +10,8 @@ from kubernetes.client.rest import ApiException
 
 from kubetest.manifest import new_object
 from kubetest.utils import label_string
+
+log = logging.getLogger('kubetest')
 
 # A global map that matches the Api Client class to its corresponding
 # apiVersion so we can get the correct client for the manifest version.
@@ -95,25 +98,31 @@ class ApiObject(abc.ABC):
         Raises:
              TimeoutError: The specified timeout was exceeded.
         """
+        log.info('waiting until ready for "%s"', self.name)
         # define the maximum time at which we should stop waiting, if set
         max_time = None
         if timeout is not None:
             max_time = time.time() + timeout
 
+        start = time.time()
         # wait until the Api Object is either in the ready state or times out
         while True:
             if max_time and time.time() >= max_time:
+                log.error('timed out while waiting to be ready')
                 raise TimeoutError(
                     'timed out ({}s) while waiting for {} to be ready'
-                    .format(timeout, self.obj.type)
+                    .format(timeout, self.obj.kind)
                 )
 
             # if the object is ready, return
             if self.is_ready():
-                return
+                break
 
             # if the object is not ready, sleep for a bit and check again
             time.sleep(1)
+
+        end = time.time()
+        log.info('wait complete (total=%f)', end - start)
 
     def wait_until_deleted(self, timeout=None):
         """Wait until the Api Object is deleted from the cluster.
@@ -128,18 +137,21 @@ class ApiObject(abc.ABC):
         Raises:
             TimeoutError: The specified timeout was exceeded.
         """
+        log.info('waiting until deleted for "%s"', self.name)
         # define the maximum time at which we should stop waiting, if set
         max_time = None
         if timeout is not None:
             max_time = time.time() + timeout
 
+        start = time.time()
         # wait until the Api Object is either removed from the cluster or
         # times out
         while True:
             if max_time and time.time() >= max_time:
+                log.error('timed out while waiting to be deleted')
                 raise TimeoutError(
                     'timed out ({}s) while waiting for {} to be deleted'
-                    .format(timeout, self.obj.type)
+                    .format(timeout, self.obj.kind)
                 )
 
             try:
@@ -148,11 +160,15 @@ class ApiObject(abc.ABC):
                 # If we can no longer find the deployment, it is deleted.
                 # If we get any other exception, raise it.
                 if e.status == 404 and e.reason == 'Not Found':
-                    return
+                    break
                 else:
+                    log.error('error refreshing object state')
                     raise e
 
             time.sleep(1)
+
+        end = time.time()
+        log.info('wait complete (total=%f)', end - start)
 
     @classmethod
     def load(cls, path):
@@ -224,6 +240,12 @@ class Configmap(ApiObject):
 
     obj_type = client.V1ConfigMap
 
+    def __str__(self):
+        return str(self.obj)
+
+    def __repr__(self):
+        return self.__str__()
+
     def create(self, namespace=None):
         """Create the ConfigMap under the given namespace.
 
@@ -236,6 +258,8 @@ class Configmap(ApiObject):
         if namespace is None:
             namespace = self.namespace
 
+        log.info('creating configmap "%s" in namespace "%s"', self.name, self.namespace)
+        log.debug('configmap: %s', self.obj)
         self.obj = client.CoreV1Api().create_namespaced_config_map(
             namespace=namespace,
             body=self.obj,
@@ -257,6 +281,8 @@ class Configmap(ApiObject):
         if options is None:
             options = client.V1DeleteOptions()
 
+        log.info('deleting configmap "%s" with options "%s"', self.name, options)
+        log.debug('configmap: %s', self.obj)
         return client.CoreV1Api().delete_namespaced_config_map(
             name=self.name,
             namespace=self.namespace,
@@ -305,6 +331,12 @@ class Container:
         self.obj = api_object
         self.pod = pod
 
+    def __str__(self):
+        return str(self.obj)
+
+    def __repr__(self):
+        return self.__str__()
+
     # TODO:
     #   - get logs (#8)
     #   - container proxy (#6)
@@ -322,6 +354,12 @@ class Deployment(ApiObject):
 
     obj_type = client.V1Deployment
 
+    def __str__(self):
+        return str(self.obj)
+
+    def __repr__(self):
+        return self.__str__()
+
     def create(self, namespace=None):
         """Create the Deployment under the given namespace.
 
@@ -334,6 +372,8 @@ class Deployment(ApiObject):
         if namespace is None:
             namespace = self.namespace
 
+        log.info('creating deployment "%s" in namespace "%s"', self.name, self.namespace)
+        log.debug('deployment: %s', self.obj)
         self.obj = self.api_client.create_namespaced_deployment(
             namespace=namespace,
             body=self.obj,
@@ -355,6 +395,8 @@ class Deployment(ApiObject):
         if options is None:
             options = client.V1DeleteOptions()
 
+        log.info('deleting deployment "%s" with options "%s"', self.name, options)
+        log.debug('deployment: %s', self.obj)
         return self.api_client.delete_namespaced_deployment(
             name=self.name,
             namespace=self.namespace,
@@ -399,6 +441,7 @@ class Deployment(ApiObject):
         Returns:
             client.V1DeploymentStatus: The status of the Deployment.
         """
+        log.info('checking status of deployment "%s"', self.name)
         # first, refresh the deployment state to ensure the latest status
         self.refresh()
 
@@ -411,11 +454,14 @@ class Deployment(ApiObject):
         Returns:
             list[Pod]: A list of pods that belong to the deployment.
         """
+        log.info('getting pods for deployment "%s"', self.name)
         pods = client.CoreV1Api().list_namespaced_pod(
             namespace=self.namespace,
             label_selector=label_string(self.obj.metadata.labels),
         )
-        return [Pod(p) for p in pods.items]
+        pods = [Pod(p) for p in pods.items]
+        log.debug('pods: %s', pods)
+        return pods
 
 
 class Pod(ApiObject):
@@ -430,6 +476,12 @@ class Pod(ApiObject):
 
     obj_type = client.V1Pod
 
+    def __str__(self):
+        return str(self.obj)
+
+    def __repr__(self):
+        return self.__str__()
+
     def create(self, namespace=None):
         """Create the Pod under the given namespace.
 
@@ -442,6 +494,8 @@ class Pod(ApiObject):
         if namespace is None:
             namespace = self.namespace
 
+        log.info('creating pod "%s" in namespace "%s"', self.name, self.namespace)
+        log.debug('pod: %s', self.obj)
         self.obj = client.CoreV1Api().create_namespaced_pod(
             namespace=namespace,
             body=self.obj,
@@ -463,6 +517,8 @@ class Pod(ApiObject):
         if options is None:
             options = client.V1DeleteOptions()
 
+        log.info('deleting pod "%s" with options "%s"', self.name, options)
+        log.debug('pod: %s', self.obj)
         return client.CoreV1Api().delete_namespaced_pod(
             name=self.name,
             namespace=self.namespace,
@@ -513,6 +569,7 @@ class Pod(ApiObject):
         Returns:
             client.V1PodStatus: The status of the Pod.
         """
+        log.info('checking status of pod "%s"', self.name)
         # first, refresh the pod state to ensure latest status
         self.refresh()
 
@@ -525,9 +582,12 @@ class Pod(ApiObject):
         Returns:
             list[Container]: A list of containers that belong to the Pod.
         """
+        log.info('getting containers for pod "%s"', self.name)
         self.refresh()
 
-        return [Container(c, self) for c in self.obj.spec.containers]
+        containers = [Container(c, self) for c in self.obj.spec.containers]
+        log.debug('contianers: %s', containers)
+        return containers
 
 
 class Service(ApiObject):
@@ -542,6 +602,12 @@ class Service(ApiObject):
 
     obj_type = client.V1Service
 
+    def __str__(self):
+        return str(self.obj)
+
+    def __repr__(self):
+        return self.__str__()
+
     def create(self, namespace=None):
         """Create the Service under the given namespace.
 
@@ -554,6 +620,8 @@ class Service(ApiObject):
         if namespace is None:
             namespace = self.namespace
 
+        log.info('creating service "%s" in namespace "%s"', self.name, self.namespace)
+        log.debug('service: %s', self.obj)
         self.obj = client.CoreV1Api().create_namespaced_service(
             namespace=namespace,
             body=self.obj,
@@ -575,6 +643,8 @@ class Service(ApiObject):
         if options is None:
             options = client.V1DeleteOptions()
 
+        log.info('deleting service "%s" with options "%s"', self.name, options)
+        log.debug('service: %s', self.obj)
         return client.CoreV1Api().delete_namespaced_service(
             name=self.name,
             namespace=self.namespace,
@@ -644,6 +714,7 @@ class Service(ApiObject):
         Returns:
             client.V1ServiceStatus: The status of the Service.
         """
+        log.info('checking status of service "%s"', self.name)
         # first, refresh the service state to ensure the latest status
         self.refresh()
 
@@ -660,6 +731,7 @@ class Service(ApiObject):
             list[client.V1Endpoints]: A list of endpoints associated
                 with the Service.
         """
+        log.info('getting endpoints for service "%s"', self.name)
         endpoints = client.CoreV1Api().list_namespaced_endpoints(
             namespace=self.namespace,
         )
@@ -671,4 +743,5 @@ class Service(ApiObject):
             if endpoint.metadata.name == self.name:
                 svc_endpoints.append(endpoint)
 
+        log.debug('endpoints: %s', svc_endpoints)
         return svc_endpoints

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands=
     ; loaded prior to running coverage agaisnt it. this means that
     ; lines that were hit were not marked as hit, since they were hit
     ; before the tests were started (e.g. on plugin import).
-    coverage run --parallel --source kubetest -m pytest --kube-disable {posargs:tests}
+    coverage run --parallel --source kubetest -m pytest -s --kube-disable {posargs:tests}
     coverage combine
     coverage html
     coverage report
@@ -41,4 +41,4 @@ deps=
     -r{toxinidir}/requirements.txt
 commands=
     pip install -e .
-    pytest examples
+    pytest -s examples --kube-log-level=debug


### PR DESCRIPTION
fixes #28 

by default, logging will be at warning level, as is the default with pytest. for general kubetest logs, the logger can be set to INFO level via command line flag `--kube-log-level=info`. Setting to DEBUG level will have the objects be logged out as well.