### PR TITLE
add response wrapper around proxy requests

### DIFF
--- a/kubetest/client.py
+++ b/kubetest/client.py
@@ -528,7 +528,7 @@ class TestClient:
             return True
 
         wait_condition = Condition(
-            'wait for {}:{} to be created'.format(type(obj), obj.name),
+            'wait for {}:{} to be created'.format(type(obj).__name__, obj.name),
             check_ready,
             obj,
         )

--- a/kubetest/objects/pod.py
+++ b/kubetest/objects/pod.py
@@ -1,6 +1,5 @@
 """Kubetest wrapper for the Kubernetes `Pod` API Object."""
 
-import json
 import logging
 
 from kubernetes import client

--- a/kubetest/response.py
+++ b/kubetest/response.py
@@ -1,0 +1,43 @@
+"""Response wrapper object for proxied requests to Kubernetes resources."""
+
+import json
+
+
+class Response:
+    """Response is a wrapper around the Kubernetes API's response data
+    when a request is proxied to a Kubernetes resource, like a Pod or
+    Service.
+
+    A proxied request will return:
+    - The response data
+    - The response headers
+    - The response HTTP code
+
+    All of these are wrapped by this class. Additional helpers are provided,
+    such as casting the response data to JSON.
+
+    Args:
+        data: The response data from the proxied request.
+        status: The response status code.
+        headers: The response headers.
+    """
+
+    def __init__(self, data, status, headers):
+        self.data = data
+        self.status = status
+        self.headers = headers
+
+    def json(self):
+        """Convert the response data to JSON.
+
+        If the response data is not valid JSON, an error will be raised.
+
+        Returns:
+            dict: The JSON data.
+        """
+        # the response data comes back as a string formatted as a python
+        # dictionary might be, where the inner quotes are single quotes
+        # (') instead of the double quotes (") expected by JSON standard.
+        # to remedy this, we just replace single quotes with double quotes.
+        data = self.data.replace("'", '"')
+        return json.loads(data)

--- a/kubetest/utils.py
+++ b/kubetest/utils.py
@@ -118,4 +118,4 @@ def wait_for_condition(condition, timeout=None, interval=1, fail_on_api_error=Tr
         time.sleep(interval)
 
     end = time.time()
-    log.info('wait completed (total=%f) %s', end - start, condition)
+    log.info('wait completed (total=%fs) %s', end - start, condition)


### PR DESCRIPTION
In this PR, we add a Response wrapper around the proxied requests to pods, and it handles the JSONification. This makes it easier for the user to handle things like a response that returns 500 or 404 -- it will now return a response instead of just raising an exception.