### PR TITLE
better resource version management

### DIFF
--- a/kubetest/objects/clusterrolebinding.py
+++ b/kubetest/objects/clusterrolebinding.py
@@ -24,6 +24,13 @@ class ClusterRoleBinding(ApiObject):
 
     obj_type = client.V1ClusterRoleBinding
 
+    api_clients = {
+        'preferred': client.RbacAuthorizationV1Api,
+        'rbac.authorization.k8s.io/v1': client.RbacAuthorizationV1Api,
+        'rbac.authorization.k8s.io/v1alpha1': client.RbacAuthorizationV1alpha1Api,
+        'rbac.authorization.k8s.io/v1beta1': client.RbacAuthorizationV1beta1Api,
+    }
+
     def __str__(self):
         return str(self.obj)
 
@@ -38,7 +45,8 @@ class ClusterRoleBinding(ApiObject):
         """
         log.info('creating clusterrolebinding "%s" in namespace "%s"', self.name, self.namespace)  # noqa
         log.debug('clusterrolebinding: %s', self.obj)
-        self.obj = client.RbacAuthorizationV1Api().create_cluster_role_binding(
+
+        self.obj = self.api_client.create_cluster_role_binding(
             body=self.obj,
         )
 
@@ -62,14 +70,14 @@ class ClusterRoleBinding(ApiObject):
         log.debug('delete options: %s', options)
         log.debug('clusterrolebinding: %s', self.obj)
 
-        return client.RbacAuthorizationV1Api().delete_cluster_role_binding(
+        return self.api_client.delete_cluster_role_binding(
             name=self.name,
             body=options,
         )
 
     def refresh(self):
         """Refresh the underlying Kubernetes ClusterRoleBinding resource."""
-        self.obj = client.RbacAuthorizationV1Api().read_cluster_role_binding(
+        self.obj = self.api_client.read_cluster_role_binding(
             name=self.name
         )
 

--- a/kubetest/objects/configmap.py
+++ b/kubetest/objects/configmap.py
@@ -24,6 +24,11 @@ class ConfigMap(ApiObject):
 
     obj_type = client.V1ConfigMap
 
+    api_clients = {
+        'preferred': client.CoreV1Api,
+        'v1': client.CoreV1Api,
+    }
+
     def __str__(self):
         return str(self.obj)
 
@@ -44,7 +49,8 @@ class ConfigMap(ApiObject):
 
         log.info('creating configmap "%s" in namespace "%s"', self.name, self.namespace)
         log.debug('configmap: %s', self.obj)
-        self.obj = client.CoreV1Api().create_namespaced_config_map(
+
+        self.obj = self.api_client.create_namespaced_config_map(
             namespace=namespace,
             body=self.obj,
         )
@@ -68,7 +74,8 @@ class ConfigMap(ApiObject):
         log.info('deleting configmap "%s"', self.name)
         log.debug('delete options: %s', options)
         log.debug('configmap: %s', self.obj)
-        return client.CoreV1Api().delete_namespaced_config_map(
+
+        return self.api_client.delete_namespaced_config_map(
             name=self.name,
             namespace=self.namespace,
             body=options,
@@ -76,7 +83,7 @@ class ConfigMap(ApiObject):
 
     def refresh(self):
         """Refresh the underlying Kubernetes ConfigMap resource."""
-        self.obj = client.CoreV1Api().read_namespaced_config_map(
+        self.obj = self.api_client.read_namespaced_config_map(
             name=self.name,
             namespace=self.namespace,
         )

--- a/kubetest/objects/deployment.py
+++ b/kubetest/objects/deployment.py
@@ -27,6 +27,13 @@ class Deployment(ApiObject):
 
     obj_type = client.V1Deployment
 
+    api_clients = {
+        'preferred': client.AppsV1Api,
+        'apps/v1': client.AppsV1Api,
+        'apps/v1beta1': client.AppsV1beta1Api,
+        'apps/v1beta2': client.AppsV1beta2Api,
+    }
+
     def __str__(self):
         return str(self.obj)
 
@@ -47,6 +54,7 @@ class Deployment(ApiObject):
 
         log.info('creating deployment "%s" in namespace "%s"', self.name, self.namespace)
         log.debug('deployment: %s', self.obj)
+
         self.obj = self.api_client.create_namespaced_deployment(
             namespace=namespace,
             body=self.obj,
@@ -71,6 +79,7 @@ class Deployment(ApiObject):
         log.info('deleting deployment "%s"', self.name)
         log.debug('delete options: %s', options)
         log.debug('deployment: %s', self.obj)
+
         return self.api_client.delete_namespaced_deployment(
             name=self.name,
             namespace=self.namespace,

--- a/kubetest/objects/namespace.py
+++ b/kubetest/objects/namespace.py
@@ -24,6 +24,11 @@ class Namespace(ApiObject):
 
     obj_type = client.V1Namespace
 
+    api_clients = {
+        'preferred': client.CoreV1Api,
+        'v1': client.CoreV1Api,
+    }
+
     def __str__(self):
         return str(self.obj)
 
@@ -60,7 +65,8 @@ class Namespace(ApiObject):
 
         log.info('creating namespace "%s"', self.name)
         log.debug('namespace: %s', self.obj)
-        self.obj = client.CoreV1Api().create_namespace(
+
+        self.obj = self.api_client.create_namespace(
             body=self.obj,
         )
 
@@ -80,14 +86,14 @@ class Namespace(ApiObject):
         log.debug('delete options: %s', options)
         log.debug('namespace: %s', self.obj)
 
-        return client.CoreV1Api().delete_namespace(
+        return self.api_client.delete_namespace(
             name=self.name,
             body=options,
         )
 
     def refresh(self):
         """Refresh the underlying Kubernetes Namespace resource."""
-        self.obj = client.CoreV1Api().read_namespace(
+        self.obj = self.api_client.read_namespace(
             name=self.name,
         )
 

--- a/kubetest/objects/pod.py
+++ b/kubetest/objects/pod.py
@@ -28,6 +28,11 @@ class Pod(ApiObject):
 
     obj_type = client.V1Pod
 
+    api_clients = {
+        'preferred': client.CoreV1Api,
+        'v1': client.CoreV1Api,
+    }
+
     def __str__(self):
         return str(self.obj)
 
@@ -48,7 +53,8 @@ class Pod(ApiObject):
 
         log.info('creating pod "%s" in namespace "%s"', self.name, self.namespace)
         log.debug('pod: %s', self.obj)
-        self.obj = client.CoreV1Api().create_namespaced_pod(
+
+        self.obj = self.api_client.create_namespaced_pod(
             namespace=namespace,
             body=self.obj,
         )
@@ -72,7 +78,8 @@ class Pod(ApiObject):
         log.info('deleting pod "%s"', self.name)
         log.debug('delete options: %s', options)
         log.debug('pod: %s', self.obj)
-        return client.CoreV1Api().delete_namespaced_pod(
+
+        return self.api_client.delete_namespaced_pod(
             name=self.name,
             namespace=self.namespace,
             body=options,
@@ -80,7 +87,7 @@ class Pod(ApiObject):
 
     def refresh(self):
         """Refresh the underlying Kubernetes Pod resource."""
-        self.obj = client.CoreV1Api().read_namespaced_pod_status(
+        self.obj = self.api_client.read_namespaced_pod_status(
             name=self.name,
             namespace=self.namespace,
         )
@@ -122,7 +129,6 @@ class Pod(ApiObject):
         Returns:
             client.V1PodStatus: The status of the Pod.
         """
-        log.info('checking status of pod "%s"', self.name)
         # first, refresh the pod state to ensure latest status
         self.refresh()
 

--- a/kubetest/objects/rolebinding.py
+++ b/kubetest/objects/rolebinding.py
@@ -24,6 +24,13 @@ class RoleBinding(ApiObject):
 
     obj_type = client.V1RoleBinding
 
+    api_clients = {
+        'preferred': client.RbacAuthorizationV1Api,
+        'rbac.authorization.k8s.io/v1': client.RbacAuthorizationV1Api,
+        'rbac.authorization.k8s.io/v1alpha1': client.RbacAuthorizationV1alpha1Api,
+        'rbac.authorization.k8s.io/v1beta1': client.RbacAuthorizationV1beta1Api,
+    }
+
     def __str__(self):
         return str(self.obj)
 
@@ -44,7 +51,8 @@ class RoleBinding(ApiObject):
 
         log.info('creating rolebinding "%s" in namespace "%s"', self.name, self.namespace)  # noqa
         log.debug('rolebinding: %s', self.obj)
-        self.obj = client.RbacAuthorizationV1Api().create_namespaced_role_binding(
+
+        self.obj = self.api_client.create_namespaced_role_binding(
             namespace=namespace,
             body=self.obj,
         )
@@ -68,7 +76,8 @@ class RoleBinding(ApiObject):
         log.info('deleting rolebinding "%s"', self.name)
         log.debug('delete options: %s', options)
         log.debug('rolebinding: %s', self.obj)
-        return client.RbacAuthorizationV1Api().delete_namespaced_role_binding(
+
+        return self.api_client.delete_namespaced_role_binding(
             namespace=self.namespace,
             name=self.name,
             body=options,
@@ -76,7 +85,7 @@ class RoleBinding(ApiObject):
 
     def refresh(self):
         """Refresh the underlying Kubernetes RoleBinding resource."""
-        self.obj = client.RbacAuthorizationV1Api().read_namespaced_role_binding(
+        self.obj = self.api_client.read_namespaced_role_binding(
             namespace=self.namespace,
             name=self.name,
         )

--- a/kubetest/objects/secret.py
+++ b/kubetest/objects/secret.py
@@ -24,6 +24,11 @@ class Secret(ApiObject):
 
     obj_type = client.V1Secret
 
+    api_clients = {
+        'preferred': client.CoreV1Api,
+        'v1': client.CoreV1Api,
+    }
+
     def __str__(self):
         return str(self.obj)
 
@@ -44,7 +49,8 @@ class Secret(ApiObject):
 
         log.info('creating secret "%s" in namespace "%s"', self.name, self.namespace)
         log.debug('secret: %s', self.obj)
-        self.obj = client.CoreV1Api().create_namespaced_secret(
+
+        self.obj = self.api_client.create_namespaced_secret(
             namespace=namespace,
             body=self.obj,
         )
@@ -68,7 +74,7 @@ class Secret(ApiObject):
         log.info('deleting secret "%s"', self.name)
         log.debug('delete options: %s', options)
         log.debug('secret: %s', self.obj)
-        return client.CoreV1Api().delete_namespaced_secret(
+        return self.api_client.delete_namespaced_secret(
             name=self.name,
             namespace=self.namespace,
             body=options,
@@ -76,7 +82,7 @@ class Secret(ApiObject):
 
     def refresh(self):
         """Refresh the underlying Kubernetes Secret resource."""
-        self.obj = client.CoreV1Api().read_namespaced_secret(
+        self.obj = self.api_client.read_namespaced_secret(
             name=self.name,
             namespace=self.namespace,
         )

--- a/kubetest/objects/service.py
+++ b/kubetest/objects/service.py
@@ -24,6 +24,11 @@ class Service(ApiObject):
 
     obj_type = client.V1Service
 
+    api_clients = {
+        'preferred': client.CoreV1Api,
+        'v1': client.CoreV1Api,
+    }
+
     def __str__(self):
         return str(self.obj)
 
@@ -44,7 +49,8 @@ class Service(ApiObject):
 
         log.info('creating service "%s" in namespace "%s"', self.name, self.namespace)
         log.debug('service: %s', self.obj)
-        self.obj = client.CoreV1Api().create_namespaced_service(
+
+        self.obj = self.api_client.create_namespaced_service(
             namespace=namespace,
             body=self.obj,
         )
@@ -68,7 +74,8 @@ class Service(ApiObject):
         log.info('deleting service "%s"', self.name)
         log.debug('delete options: %s', options)
         log.debug('service: %s', self.obj)
-        return client.CoreV1Api().delete_namespaced_service(
+
+        return self.api_client.delete_namespaced_service(
             name=self.name,
             namespace=self.namespace,
             body=options,
@@ -76,7 +83,7 @@ class Service(ApiObject):
 
     def refresh(self):
         """Refresh the underlying Kubernetes Service resource."""
-        self.obj = client.CoreV1Api().read_namespaced_service(
+        self.obj = self.api_client.read_namespaced_service(
             name=self.name,
             namespace=self.namespace,
         )
@@ -155,7 +162,7 @@ class Service(ApiObject):
             with the Service.
         """
         log.info('getting endpoints for service "%s"', self.name)
-        endpoints = client.CoreV1Api().list_namespaced_endpoints(
+        endpoints = self.api_client.list_namespaced_endpoints(
             namespace=self.namespace,
         )
 


### PR DESCRIPTION
fixes #76 

> **Note:** This isn't the prettiest solution. I initially tried to get apiVersion info and preferred version from the kubernetes api directly (see: https://github.com/kubernetes-client/python/blob/master/examples/example3.py), but that was not working with my cluster. Perhaps in the future, this approach could be investigated again, but for now  this solution will work.