### PR TITLE
patch: update requests dep for CVE-2018-18074

### DIFF
--- a/kubetest/__init__.py
+++ b/kubetest/__init__.py
@@ -1,7 +1,7 @@
 """kubetest -- a Kubernetes integration test framework in Python."""
 
 __title__ = 'kubetest'
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 __description__ = 'A Kubernetes integration test framework in Python.'
 __author__ = 'Vapor IO'
 __author_email__ = 'vapor@vapor.io'

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ pytest==3.8.0
 python-dateutil==2.7.3    # via adal, kubernetes
 pyyaml==3.13
 requests-oauthlib==1.0.0  # via kubernetes
-requests==2.19.1          # via adal, kubernetes, requests-oauthlib
+requests==2.20.0
 rsa==3.4.2                # via google-auth
 six==1.11.0               # via cryptography, google-auth, kubernetes, more-itertools, pytest, python-dateutil, websocket-client
 urllib3==1.23             # via kubernetes, requests

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
     install_requires=[
         'kubernetes',
         'pyyaml',
-        'pytest'
+        'pytest',
+        'requests>=2.20.0',  # used by 'kubernetes'
     ],
     tests_require=[],
     zip_safe=False,


### PR DESCRIPTION
This PR updates the version of `requests` to 2.20.0 to patch the [CVE-2018-18074](https://nvd.nist.gov/vuln/detail/CVE-2018-18074) vulnerability found in `requests<=2.19.1`.

Bumps the version to 0.0.2 for patch release.