### PR TITLE
Make manifest load support multi-document YAML files

### DIFF
--- a/kubetest/manifest.py
+++ b/kubetest/manifest.py
@@ -24,7 +24,7 @@ def load_file(path):
         A list of the Kubernetes API objects for this manifest file.
     """
     with open(path, 'r') as f:
-        manifests = yaml.load_all(f)
+        manifests = yaml.load_all(f, Loader=yaml.SafeLoader)
 
         objs = []
         for manifest in manifests:

--- a/kubetest/markers.py
+++ b/kubetest/markers.py
@@ -93,7 +93,7 @@ def apply_manifest_from_marker(item, client):
         if files is None:
             objs = load_path(dir_path)
         else:
-            objs = [load_file(os.path.join(dir_path, f)) for f in files]
+            objs = [obj for objs in load_file(os.path.join(dir_path, f)) for f in files]
 
         # For each of the loaded Kubernetes resources, we'll want to wrap it
         # in the equivalent kubetest wrapper. If the resource does not have


### PR DESCRIPTION
YAML files can contain multiple YAML documents separated by `---` which
is pretty useful in order to have only one file for a service back by a
deployment.

The problem is loading such multi-document YAML file does not work, and
I get this error:
```
self = <yaml.loader.FullLoader object at 0x7f81bc217048>

    def get_single_node(self):
        # Drop the STREAM-START event.
        self.get_event()

        # Compose a document if the stream is not empty.
        document = None
        if not self.check_event(StreamEndEvent):
            document = self.compose_document()

        # Ensure that the stream contains no more documents.
        if not self.check_event(StreamEndEvent):
            event = self.get_event()
raise ComposerError("expected a single document in the
stream",
                    document.start_mark, "but found another document",
>                   event.start_mark)
E           yaml.composer.ComposerError: expected a single document in
the stream
E             in "my_multidoc.yaml", line 1, column 1
E           but found another document
E             in "my_multidoc.yaml", line 22, column 1
```

I have added the support for this kind of files in
`@pytest.mark.applymanifests` by using `yaml.load_all()` instead of
`yaml.load()`.

This change makes `load_file` function returns a list instead of a
single element.