### PR TITLE
fix various bugs missed in recent update for multi-doc yamls

### DIFF
--- a/kubetest/manifest.py
+++ b/kubetest/manifest.py
@@ -12,10 +12,10 @@ from kubernetes.client import models
 
 
 def load_file(path):
-    """
-    Load an individual Kubernetes manifest YAML file. This file may contain
-    multiple document. It will attempt to auto-detect the type of each object
-    to load.
+    """Load an individual Kubernetes manifest YAML file.
+
+    This file may contain multiple YAML documents. It will attempt to auto-detect
+    the type of each object to load.
 
     Args:
         path (str): The fully qualified path to the file.

--- a/kubetest/markers.py
+++ b/kubetest/markers.py
@@ -96,7 +96,7 @@ def apply_manifest_from_marker(item, client):
             path = os.path.abspath(path)
 
         # Load the manifest
-        obj = load_file(path)
+        objs = load_file(path)
 
         # For each of the loaded Kubernetes resources, wrap it in the
         # equivalent kubetest wrapper. If the object does not yet have a
@@ -104,16 +104,17 @@ def apply_manifest_from_marker(item, client):
         # without our ApiObject wrapper semantics.
         wrapped = []
         found = False
-        for klass in ApiObject.__subclasses__():
-            if obj.kind == klass.__name__:
-                wrapped.append(klass(obj))
-                found = True
-                break
-        if not found:
-            raise ValueError(
-                'Unable to match loaded object to an internal wrapper '
-                'class: {}'.format(obj)
-            )
+        for obj in objs:
+            for klass in ApiObject.__subclasses__():
+                if obj.kind == klass.__name__:
+                    wrapped.append(klass(obj))
+                    found = True
+                    break
+            if not found:
+                raise ValueError(
+                    'Unable to match loaded object to an internal wrapper '
+                    'class: {}'.format(obj)
+                )
 
         client.register_objects(wrapped)
 
@@ -150,7 +151,7 @@ def apply_manifests_from_marker(item, client):
         if files is None:
             objs = load_path(dir_path)
         else:
-            objs = [obj for objs in load_file(os.path.join(dir_path, f)) for f in files]
+            objs = [obj for obj in load_file(os.path.join(dir_path, f)) for f in files]
 
         # For each of the loaded Kubernetes resources, we'll want to wrap it
         # in the equivalent kubetest wrapper. If the resource does not have

--- a/kubetest/objects/api_object.py
+++ b/kubetest/objects/api_object.py
@@ -202,8 +202,13 @@ class ApiObject(abc.ABC):
             ApiObject: The API object wrapper corresponding to the configuration
             loaded from manifest YAML file.
         """
-        obj = load_file(path, cls.obj_type)
-        return cls(obj)
+        objs = load_file(path)
+        if len(objs) != 1:
+            raise ValueError(
+                'Unable to load resource from file - multiple resources found '
+                'in specified file.'
+            )
+        return cls(objs[0])
 
     @abc.abstractmethod
     def create(self, namespace=None):


### PR DESCRIPTION
This PR fixes a couple bugs I missed in #99, mostly related to the change in return type of `load_file`.

Still need to add formal unit tests, but this gets things working for now. Getting good test coverage will likely be a larger work item, as the code will likely need a bit of refactoring to make it easier to test/maintain.