### PR TITLE
update dependencies for CVE-2019-11324

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ deps:  ## Update the frozen pip dependencies (requirements.txt)
 ifndef HAS_PIP_COMPILE
 	pip install pip-tools
 endif
-	pip-compile --update --output-file requirements.txt setup.py
+	pip-compile --upgrade --output-file requirements.txt setup.py
 
 .PHONY: docs
 docs:  ## Build the kubetest docs locally

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,12 +18,12 @@ pluggy==0.9.0             # via pytest
 py==1.8.0                 # via pytest
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via pyasn1-modules, rsa
-pytest==4.4.0
+pytest==4.4.1
 python-dateutil==2.8.0    # via kubernetes
 pyyaml==5.1
 requests-oauthlib==1.2.0  # via kubernetes
 requests==2.21.0
 rsa==4.0                  # via google-auth
 six==1.12.0               # via google-auth, kubernetes, pytest, python-dateutil, websocket-client
-urllib3==1.24.1           # via kubernetes, requests
+urllib3==1.24.2           # via kubernetes, requests
 websocket-client==0.56.0  # via kubernetes

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'kubernetes',
         'pyyaml>=4.2b1',
         'pytest',
-        'requests>=2.20.0',  # used by 'kubernetes'
+        'requests>=2.21.0',  # used by 'kubernetes'
     ],
     tests_require=[],
     zip_safe=False,


### PR DESCRIPTION
* updates the `requests` lib, which uses `urllib3`, to bump `urllib3` to `>=1.24.2` (see: [CVE-2019-11324](https://nvd.nist.gov/vuln/detail/CVE-2019-11324))