### PR TITLE
fix typos in client api usage

### DIFF
--- a/kubetest/objects/statefulset.py
+++ b/kubetest/objects/statefulset.py
@@ -137,7 +137,7 @@ class StatefulSet(ApiObject):
         log.debug('delete options: %s', options)
         log.debug('statefulset: %s', self.obj)
 
-        return self.api_client.delete_namespaced_statefulset(
+        return self.api_client.delete_namespaced_stateful_set(
             name=self.name,
             namespace=self.namespace,
             body=options,
@@ -145,7 +145,7 @@ class StatefulSet(ApiObject):
 
     def refresh(self):
         """Refresh the underlying Kubernetes StatefulSet resource."""
-        self.obj = self.api_client.read_namespaced_statefulset_status(
+        self.obj = self.api_client.read_namespaced_stateful_set_status(
             name=self.name,
             namespace=self.namespace,
         )

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ deps=
     autopep8
 commands=
     isort --recursive --atomic {posargs:kubetest tests}
-    autopep8 --recursive --in-place {toxinidir}
+    autopep8 --recursive --in-place --exclude=conf.py {toxinidir}
 
 
 [testenv:lint]


### PR DESCRIPTION
missed this in the PR review.. minor bug in kubernetes lib api usage