### PR TITLE
Don't call test teardown if kube-config argument wasn't provided

### DIFF
--- a/kubetest/plugin.py
+++ b/kubetest/plugin.py
@@ -241,7 +241,8 @@ def pytest_runtest_teardown(item):
     See Also:
         https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_runtest_teardown
     """
-    manager.teardown(item.nodeid)
+    if hasattr(item.config, 'kube_config'):
+        manager.teardown(item.nodeid)
 
 
 def pytest_runtest_makereport(item, call):


### PR DESCRIPTION
I've ran into an issue where I have the kubetest plugin installed but I'm running tests that don't use it and I don't want to supply a `--kube-config` cli arg in such case.
The tests are running okay but `teardown` calls are failing because it is trying to delete the test namespace (that wasn't even created) from a cluster on `localhost:443`.

I hope you will approve it because without it I'm in quite a jam.

Thanks!