### PR TITLE
On teardown, check that namespace was created before trying to delete it

### DIFF
--- a/kubetest/manager.py
+++ b/kubetest/manager.py
@@ -199,7 +199,8 @@ class TestMeta:
 
         # delete the test case namespace. this will also delete anything
         # in the namespace, which includes RoleBindings.
-        self.namespace.delete()
+        if self._namespace:
+            self.namespace.delete()
 
         # ClusterRoleBindings are not bound to a namespace, so we will need
         # to delete them ourselves.

--- a/kubetest/plugin.py
+++ b/kubetest/plugin.py
@@ -248,7 +248,7 @@ def pytest_runtest_teardown(item):
     See Also:
         https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_runtest_teardown
     """
-    if hasattr(item.config, 'kube_config'):
+    if item.config.getoption('kube_config'):
         manager.teardown(item.nodeid)
 
 


### PR DESCRIPTION
i've encountered another "corner case":
I'm running a test suite built from both tests that use `kubetest` and tests that don't use it, so `--kube-config` argument is supplied in cli.
**But**, for the tests that don't use `kubetest`, the `kube` fixture is not instantiated --> `manager.setup()` is not called and the `_namespace` **variable** remains `None`. When `manager.teardown()` is called (because `--kube-config` arg was supplied) it is trying to delete the test's namespace by using the `namespace` **property** (which creates a value if the variable is `None`).

I hope I explained myself ok and that the proposed solution is acceptable.