### PR TITLE
Adding read-only support for k8s Event object

### DIFF
--- a/kubetest/client.py
+++ b/kubetest/client.py
@@ -534,6 +534,42 @@ class TestClient:
 
         return nodes
 
+    def get_events(self, fields=None, labels=None, all_namespaces=False):
+        """Get the latest Events that occurred in the cluster.
+
+        Args:
+            fields (dict[str, str]): A dictionary of fields used to restrict
+                the returned collection of Events to only those which match
+                these field selectors. By default, no restricting is done.
+            labels (dict[str, str]): A dictionary of labels used to restrict
+                the returned collection of Events to only those which match
+                these label selectors. By default, no restricting is done.
+            all_namespaces (bool): If True, get the events across all
+                namespaces.
+
+        Returns:
+            dict[str, objects.Event]: A dictionary where the key is the Event
+            name and the value is the Event itself.
+        """
+        selectors = utils.selector_kwargs(fields, labels)
+
+        if all_namespaces:
+            event_list = client.CoreV1Api().list_event_for_all_namespaces(
+                **selectors
+            )
+        else:
+            event_list = client.CoreV1Api().list_namespaced_event(
+                namespace=self.namespace,
+                **selectors
+            )
+
+        events = {}
+        for obj in event_list.items:
+            event = objects.Event(obj)
+            events[event.name] = event
+
+        return events
+
     # ****** Test Helpers ******
 
     @staticmethod

--- a/kubetest/objects/__init__.py
+++ b/kubetest/objects/__init__.py
@@ -9,6 +9,7 @@ from .container import Container
 from .daemonset import DaemonSet
 from .deployment import Deployment
 from .endpoints import Endpoints
+from .event import Event
 from .namespace import Namespace
 from .node import Node
 from .pod import Pod

--- a/kubetest/objects/event.py
+++ b/kubetest/objects/event.py
@@ -1,0 +1,40 @@
+"""Kubetest wrapper for the Kubernetes ``Event`` API Object."""
+
+import logging
+
+from kubernetes import client
+
+log = logging.getLogger('kubetest')
+
+
+class Event:
+    """Kubetest wrapper around a Kubernetes `Event`_ API Object.
+
+    The actual ``kubernetes.client.V1Event`` instance that this
+    wraps can be accessed via the ``obj`` instance member.
+
+    This wrapper does **NOT** subclass the ``objects.ApiObject`` like
+    other object wrappers because it is not intended to be created or
+    managed from manifest file. It is merely meant to wrap the
+    Event object to make Event-based interactions easier
+
+    .. _Event:
+        https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#event-v1-core
+    """
+
+    obj_type = client.V1Event
+
+    api_clients = {
+        'preferred': client.CoreV1Api,
+        'v1': client.CoreV1Api,
+    }
+
+    def __init__(self, api_object):
+        self.obj = api_object
+        self.name = api_object.metadata.name
+
+    def __str__(self):
+        return str(self.obj)
+
+    def __repr__(self):
+        return self.__str__()


### PR DESCRIPTION
Similar to the existing support for Node objects, Event object can only be read from the API server to make Event-based interactions easier.