### PR TITLE
add support for HTTP POST to a pod

### DIFF
--- a/examples/configs/deployment.yaml
+++ b/examples/configs/deployment.yaml
@@ -16,16 +16,13 @@ spec:
     spec:
       terminationGracePeriodSeconds: 3
       containers:
-      - name: synse-server
-        image: vaporio/synse-server:latest
+      - name: http-listener
+        image: mendhak/http-https-echo
         ports:
         - name: http
-          containerPort: 5000
-        args: [ 'enable-emulator' ]
-        env:
-        # Enable debug logging via ENV config
-        - name: SYNSE_LOGGING
-          value: debug
+          containerPort: 80
+        - name: https
+          containerPort: 443
         resources:
           requests:
             cpu: 25m

--- a/examples/configs/service.yaml
+++ b/examples/configs/service.yaml
@@ -10,6 +10,6 @@ spec:
     app: test
   ports:
   - protocol: TCP
-    port: 5000
+    port: 8080
     targetPort: http
     name: http

--- a/examples/test_deployment.py
+++ b/examples/test_deployment.py
@@ -2,6 +2,8 @@
 
 import os
 
+import time
+
 
 def test_deployment(kube):
 
@@ -23,6 +25,41 @@ def test_deployment(kube):
 
     p = pods[0]
     p.wait_until_ready(timeout=10)
+
+    # Issue an HTTP GET against the Pod. The deployment
+    # is an http echo server, so we should get back data
+    # about the request.
+    r = p.http_proxy_get(
+        '/test/get',
+        query_params={'abc': 123},
+    )
+    get_data = r.json()
+    assert get_data['path'] == '/test/get'
+    assert get_data['method'] == 'GET'
+    assert get_data['body'] == ''
+    # fixme (etd): I would expect this to be {'abc': 123}, matching
+    #   the input data types (e.g. value not a string). Need to determine
+    #   where this issue lies..
+    #   This may be an issue with the image reflecting the request back.
+    assert get_data['query'] == {'abc': '123'}
+
+    # Issue an HTTP POST against the Pod. The deployment
+    # is an http echo server, so we should get back data
+    # about the request.
+    r = p.http_proxy_post(
+        '/test/post',
+        query_params={'abc': 123},
+        data='foobar',
+    )
+    post_data = r.json()
+    assert post_data['path'] == '/test/post'
+    assert post_data['method'] == 'POST'
+    assert post_data['body'] == '"foobar"'
+    # fixme (etd): I would expect this to be {'abc': 123}, matching
+    #   the input data types (e.g. value not a string). Need to determine
+    #   where this issue lies..
+    #   This may be an issue with the image reflecting the request back.
+    assert post_data['query'] == {'abc': '123'}
 
     containers = p.get_containers()
     c = containers[0]

--- a/examples/test_service.py
+++ b/examples/test_service.py
@@ -30,12 +30,12 @@ def test_service(kube):
     endpoints = svc.get_endpoints()
     assert len(endpoints) == 1
 
-    resp = svc.proxy_http_get("synse/test")
+    resp = svc.proxy_http_get("test/get")
     assert len(resp) != 0
 
     d = ast.literal_eval(resp)
-    assert d.get("status") == "ok"
-    assert d.get("timestamp") is not None
+    assert d.get("path") == "/test/get"
+    assert d.get("method") == "GET"
 
     kube.delete(svc)
     kube.delete(dep)

--- a/kubetest/response.py
+++ b/kubetest/response.py
@@ -2,6 +2,8 @@
 
 import json
 
+import urllib3
+
 
 class Response:
     """Response is a wrapper around the Kubernetes API's response data
@@ -35,6 +37,21 @@ class Response:
         Returns:
             dict: The JSON data.
         """
+        # This should generally be the case, since the primary source of Response
+        # instances are the HTTP methods on Pods (e.g. http_proxy_get), where
+        # `_preload_content=False`. Should that be set to True, it will not return
+        # the HTTPResponse but will instead return the response data formatted as
+        # the type specified in the `response_type` param.
+        #
+        # Note that I have found setting _preload_content to True (the default value
+        # for the Kubernetes client) to be difficult to deal with from a generic interface
+        # because it requires you to know the expected output ("str", "dict", ...)
+        # and pass that in as a param, where that could really be abstracted away from
+        # the user. For that reason, it is currently set to False -- this may change
+        # in the future if desired.
+        if isinstance(self.data, urllib3.HTTPResponse):
+            return json.loads(self.data.data)
+
         # the response data comes back as a string formatted as a python
         # dictionary might be, where the inner quotes are single quotes
         # (') instead of the double quotes (") expected by JSON standard.


### PR DESCRIPTION
fixes #126 

This PR:
- adds a `http_proxy_post` method for POSTing to pods
- updates the test example to use this, updating the backend deployment to an http echo server
- updates example test expectations accordingly

@plyte -- let me know how this looks to you