### PR TITLE
bug: fix opaque type errors generated from failed requests on pod proxy get/post

### DIFF
--- a/kubetest/__init__.py
+++ b/kubetest/__init__.py
@@ -1,7 +1,7 @@
 """kubetest -- a Kubernetes integration test framework in Python."""
 
 __title__ = 'kubetest'
-__version__ = '0.3.3'
+__version__ = '0.3.4'
 __description__ = 'A Kubernetes integration test framework in Python.'
 __author__ = 'Vapor IO'
 __author_email__ = 'vapor@vapor.io'

--- a/kubetest/objects/pod.py
+++ b/kubetest/objects/pod.py
@@ -224,7 +224,7 @@ class Pod(ApiObject):
                 response_type='str',
                 auth_settings=auth_settings,
                 _return_http_data_only=False,  # we want all info, not just data
-                _preload_content=False,
+                _preload_content=True,
                 _request_timeout=None,
                 collection_formats={}
             ))
@@ -293,7 +293,7 @@ class Pod(ApiObject):
                 response_type='str',
                 auth_settings=auth_settings,
                 _return_http_data_only=False,  # we want all info, not just data
-                _preload_content=False,
+                _preload_content=True,
                 _request_timeout=None,
                 collection_formats={}
             ))


### PR DESCRIPTION
This should fix #128 

This PR also includes a patch version bump in anticipation of it being merged.

The major changes here are:
- revert back to enabling `_preload_content` on the kubernetes request
- parse the response with `ast.literal_eval` first, falling back to `json.load`
- added/updated in-line comments regarding these changes