### PR TITLE
temporarily avoid matching on label

### DIFF
--- a/kubetest/objects/deployment.py
+++ b/kubetest/objects/deployment.py
@@ -197,7 +197,7 @@ class Deployment(ApiObject):
 
         pods = client.CoreV1Api().list_namespaced_pod(
             namespace=self.namespace,
-            label_selector=selector_string({self.klabel_key: self.klabel_uid})
+      #      label_selector=selector_string({self.klabel_key: self.klabel_uid})
         )
 
         pods = [Pod(p) for p in pods.items]


### PR DESCRIPTION
**Don't merge**
Just for discussion... 

Related to

- #88 ?
- #106 ?


On my minikube local cluster, I have never seen the labels match, so this selector means I never get any pods returned.

I've removed the selector and seem to be making progress setting up tests. If I can get a bit further along, I'll come back and see if I can contribute a proper solution.