### PR TITLE
Try to retrive container logs only if kube fixture was used

### DIFF
--- a/kubetest/plugin.py
+++ b/kubetest/plugin.py
@@ -266,7 +266,7 @@ def pytest_runtest_makereport(item, call):
     See Also:
         https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_runtest_makereport
     """
-    if call.when == 'call':
+    if 'kube' in item.fixturenames and call.when == 'call':
         if call.excinfo is not None and call.excinfo.typename != 'Skipped':
             tail_lines = item.config.getoption('kube_error_log_lines')
             if tail_lines != 0:


### PR DESCRIPTION
I've encountered a situation where `pytest_runtest_makereport` is trying to retrieve logs at the end of a test case that didn't include the `kube` fixture at all. This causes the pytest output to contain irrelevant warnings since the plugin is trying to reach pods from a namespace that doesn't exist.
The fix is pretty simple I believe.