### PR TITLE
feature: add kubernetes api_client parameter to kubetest client

### DIFF
--- a/kubetest/client.py
+++ b/kubetest/client.py
@@ -30,6 +30,17 @@ class TestClient:
         self.namespace = namespace
         self.pre_registered = []
 
+        self._api_client = None
+
+    @property
+    def api_client(self):
+        """"""
+        return self._api_client
+
+    @api_client.setter
+    def api_client(self, value):
+        self._api_client = value
+
     # ****** Manifest Loaders ******
 
     @staticmethod
@@ -277,7 +288,7 @@ class TestClient:
         """
         selectors = utils.selector_kwargs(fields, labels)
 
-        namespace_list = client.CoreV1Api().list_namespace(
+        namespace_list = client.CoreV1Api(api_client=self.api_client).list_namespace(
             **selectors,
         )
 
@@ -311,7 +322,7 @@ class TestClient:
 
         selectors = utils.selector_kwargs(fields, labels)
 
-        deployment_list = client.AppsV1Api().list_namespaced_deployment(
+        deployment_list = client.AppsV1Api(api_client=self.api_client).list_namespaced_deployment(
             namespace=namespace,
             **selectors,
         )
@@ -346,7 +357,7 @@ class TestClient:
 
         selectors = utils.selector_kwargs(fields, labels)
 
-        statefulset_list = client.AppsV1Api().list_namespaced_stateful_set(
+        statefulset_list = client.AppsV1Api(api_client=self.api_client).list_namespaced_stateful_set(
             namespace=namespace,
             **selectors,
         )
@@ -381,7 +392,7 @@ class TestClient:
 
         selectors = utils.selector_kwargs(fields, labels)
 
-        daemonset_list = client.AppsV1Api().list_namespaced_daemon_set(
+        daemonset_list = client.AppsV1Api(api_client=self.api_client).list_namespaced_daemon_set(
             namespace=namespace,
             **selectors,
         )
@@ -416,7 +427,7 @@ class TestClient:
 
         selectors = utils.selector_kwargs(fields, labels)
 
-        endpoints_list = client.CoreV1Api().list_namespaced_endpoints(
+        endpoints_list = client.CoreV1Api(api_client=self.api_client).list_namespaced_endpoints(
             namespace=namespace,
             **selectors,
         )
@@ -451,7 +462,7 @@ class TestClient:
 
         selectors = utils.selector_kwargs(fields, labels)
 
-        secret_list = client.CoreV1Api().list_namespaced_secret(
+        secret_list = client.CoreV1Api(api_client=self.api_client).list_namespaced_secret(
             namespace=namespace,
             **selectors,
         )
@@ -486,7 +497,7 @@ class TestClient:
 
         selectors = utils.selector_kwargs(fields, labels)
 
-        configmap_list = client.CoreV1Api().list_namespaced_config_map(
+        configmap_list = client.CoreV1Api(api_client=self.api_client).list_namespaced_config_map(
             namespace=namespace,
             **selectors,
         )
@@ -521,7 +532,7 @@ class TestClient:
 
         selectors = utils.selector_kwargs(fields, labels)
 
-        pod_list = client.CoreV1Api().list_namespaced_pod(
+        pod_list = client.CoreV1Api(api_client=self.api_client).list_namespaced_pod(
             namespace=namespace,
             **selectors,
         )
@@ -556,7 +567,7 @@ class TestClient:
 
         selectors = utils.selector_kwargs(fields, labels)
 
-        service_list = client.CoreV1Api().list_namespaced_service(
+        service_list = client.CoreV1Api(api_client=self.api_client).list_namespaced_service(
             namespace=namespace,
             **selectors,
         )
@@ -568,8 +579,7 @@ class TestClient:
 
         return services
 
-    @staticmethod
-    def get_nodes(fields=None, labels=None):
+    def get_nodes(self, fields=None, labels=None):
         """Get the Nodes that make up the cluster.
 
         Args:
@@ -586,7 +596,7 @@ class TestClient:
         """
         selectors = utils.selector_kwargs(fields, labels)
 
-        node_list = client.CoreV1Api().list_node(
+        node_list = client.CoreV1Api(api_client=self.api_client).list_node(
             **selectors,
         )
 
@@ -617,11 +627,11 @@ class TestClient:
         selectors = utils.selector_kwargs(fields, labels)
 
         if all_namespaces:
-            event_list = client.CoreV1Api().list_event_for_all_namespaces(
+            event_list = client.CoreV1Api(api_client=self.api_client).list_event_for_all_namespaces(
                 **selectors
             )
         else:
-            event_list = client.CoreV1Api().list_namespaced_event(
+            event_list = client.CoreV1Api(api_client=self.api_client).list_namespaced_event(
                 namespace=self.namespace,
                 **selectors
             )

--- a/kubetest/objects/api_object.py
+++ b/kubetest/objects/api_object.py
@@ -47,13 +47,20 @@ class ApiObject(abc.ABC):
     is not specified for the resource.
     '''
 
-    def __init__(self, api_object):
+    def __init__(self, api_object, client=None):
         # The underlying Kubernetes Api Object
         self.obj = api_object
 
         # The api client for the object. This will be determined
         # by the apiVersion of the object's manifest.
         self._api_client = None
+
+        # The underlying client which is used by the api client, above.
+        # The naming of this is a bit confusing, but here the "api_client"
+        # can be thought of as the Kubernetes versioned client (e.g. AppsV1Api)
+        # whereas this "client" is the generic ApiClient which underlays the
+        # versioned client.
+        self._client = client
 
     @property
     def version(self):
@@ -111,7 +118,7 @@ class ApiObject(abc.ABC):
                         'defined for resource ({})'.format(self.version)
                     )
             # If we did find it, initialize that client version.
-            self._api_client = c()
+            self._api_client = c(api_client=self._client)
         return self._api_client
 
     def wait_until_ready(self, timeout=None, interval=1, fail_on_api_error=False):

--- a/kubetest/utils.py
+++ b/kubetest/utils.py
@@ -35,7 +35,7 @@ def new_namespace(test_name):
     name_len = len(prefix) + len(timestamp) + len(test_name) + 2
 
     if name_len > 63:
-        test_name = test_name[:-(name_len-63)]
+        test_name = test_name[:-(name_len - 63)]
 
     return '-'.join((prefix, test_name, timestamp))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,4 +11,5 @@ license_file = LICENSE
 
 [flake8]
 max-line-length = 90
+ignore=E501
 exclude = lib/,src/,docs/,bin/,.tox/

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ from kubetest import utils
         ('Test1_FOO-BAR_2', 'kubetest-test1-foo-bar-2-1536849367'),
         ('123456', 'kubetest-123456-1536849367'),
         ('___', 'kubetest-----1536849367'),
-        ('test-'*14, 'kubetest-test-test-test-test-test-test-test-test-tes-1536849367')
+        ('test-' * 14, 'kubetest-test-test-test-test-test-test-test-test-tes-1536849367')
     ]
 )
 def test_new_namespace(name, expected):


### PR DESCRIPTION
This PR:
- allows tests to specify their own `api_client` parameter to pass to the Kubernetes client.
- allows kubernetes objects to specify their own `api_client`


Caveats:
- In order for the test client (e.g. returned by the `kube` fixture) to use a custom api_client, the test author must manually set it at the top of the test, e.g.
    ```py
    def test_something(kube):
        kube.api_client = custom_client
        
        kube.load_deployment(...)
    ```

- Interactions through the `kube` client will have access to the custom client and will use it if set, however if any of the kubetest object wrappers (e.g. `kubetest.objects.deployment.Deployment`) are initialized manually:
    ```py
    d = Deployment(obj)
    ```

    then they will not have access to the custom client because there is no direct link to the currently active test client. it could be added in the future, but that requires a hard look at the design and any implications it would have, particularly if tests are run in parallel. For now, if its required that an object is initialized directly, the `api_client` can be passed directly to it
    ```py
    d = Deployment(obj, client=custom_client)
    ```


Related: 
* #133