### PR TITLE
Avoid overwriting label when re-initialising Deployment object

### DIFF
--- a/kubetest/objects/daemonset.py
+++ b/kubetest/objects/daemonset.py
@@ -54,8 +54,10 @@ class DaemonSet(ApiObject):
         The kubetest label key is "kubetest/<obj kind>" where the obj kind is
         the lower-cased kind of the obj.
         """
-        self.klabel_uid = str(uuid.uuid4())
         self.klabel_key = 'kubetest/daemonset'
+        self.klabel_uid = self.obj.metadata.labels.get(self.klabel_key, None)
+        if not self.klabel_uid:
+            self.klabel_uid = str(uuid.uuid4())
 
         # fixme: it would be nice to clean up this label setting logic a bit
         #   and possibly abstract it out to something more generalized, but

--- a/kubetest/objects/deployment.py
+++ b/kubetest/objects/deployment.py
@@ -54,8 +54,10 @@ class Deployment(ApiObject):
         The kubetest label key is "kubetest/<obj kind>" where the obj kind is
         the lower-cased kind of the obj.
         """
-        self.klabel_uid = str(uuid.uuid4())
         self.klabel_key = 'kubetest/deployment'
+        self.klabel_uid = self.obj.metadata.labels.get(self.klabel_key, None)
+        if not self.klabel_uid:
+            self.klabel_uid = str(uuid.uuid4())
 
         # fixme: it would be nice to clean up this label setting logic a bit
         #   and possibly abstract it out to something more generalized, but

--- a/kubetest/objects/statefulset.py
+++ b/kubetest/objects/statefulset.py
@@ -54,8 +54,10 @@ class StatefulSet(ApiObject):
         The kubetest label key is "kubetest/<obj kind>" where the obj kind is
         the lower-cased kind of the obj.
         """
-        self.klabel_uid = str(uuid.uuid4())
         self.klabel_key = 'kubetest/statefulset'
+        self.klabel_uid = self.obj.metadata.labels.get(self.klabel_key, None)
+        if not self.klabel_uid:
+            self.klabel_uid = str(uuid.uuid4())
 
         # fixme: it would be nice to clean up this label setting logic a bit
         #   and possibly abstract it out to something more generalized, but


### PR DESCRIPTION
When I run the first example using the latest version on pip (0.4.2), the Nginx test fails with:
```
>       assert len(pods) == 3, 'nginx should deploy with three replicas'
E       AssertionError: nginx should deploy with three replicas
E       assert 0 == 3
E        +  where 0 = len([])
```
Some debugging showed that `_add_kubetest_labels()` is called twice: once by the `applymanifests` decorator, and once during `deployments.get_deployments()`. This results in the Deployment and Pods having differed UIDs, which causes `get_pods()` to return an empty list.

This patch fixes the problem by first checking to see if the deployment already has a UID label in its metadata. If so it is retrieved from the Deployment's label, instead of overwritten by a new UID.

There are already some PRs relating to this issue (e.g. #142), but label-based matching seems like a nice solution to the problem and disabling it entirely might lead to unpredictable results in more advanced multi-deployment test cases.

I lack sufficient familiarity with the codebase to know if this is the correct fix, but it is enough to get the example tests working as expected. I only tested deployments but statefulsets/daemonsets share the same code so presumably have the same issue.