### PR TITLE
fix bug in namespace generation for parameterized tests

### DIFF
--- a/kubetest/utils.py
+++ b/kubetest/utils.py
@@ -27,6 +27,8 @@ def new_namespace(test_name):
     prefix = 'kubetest'
     timestamp = str(int(time.time()))
     test_name = test_name.replace('_', '-').lower()
+    test_name = test_name.replace('[', '-')
+    test_name = test_name.replace(']', '-')
 
     # The length of a resource name in Kubernetes may not exceed 63
     # characters. Check the length of all components (+2 for the dashes

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,8 @@ from kubetest import utils
         ('Test1_FOO-BAR_2', 'kubetest-test1-foo-bar-2-1536849367'),
         ('123456', 'kubetest-123456-1536849367'),
         ('___', 'kubetest-----1536849367'),
-        ('test-'*14, 'kubetest-test-test-test-test-test-test-test-test-tes-1536849367')
+        ('test-'*14, 'kubetest-test-test-test-test-test-test-test-test-tes-1536849367'),
+        ('test[a]-foo', 'kubetest-test-a--foo-1536849367'),
     ]
 )
 def test_new_namespace(name, expected):


### PR DESCRIPTION
This PR:
- fixes a bug where namespace creation fails for parameterized tests because pytest includes `[` and `]` in the name, which are illegal ns characters.

fixes #146 