### PR TITLE
update example so test can run at any directory level

### DIFF
--- a/examples/get-all-pods-via-fixture/test_examples.py
+++ b/examples/get-all-pods-via-fixture/test_examples.py
@@ -1,9 +1,10 @@
 
 import pytest
 import time
+import os
 
 
-@pytest.mark.applymanifest('manifests/deployment-redis.yaml')
+@pytest.mark.applymanifest(os.path.join(os.path.dirname(__file__), 'manifests/deployment-redis.yaml'))
 def test_pods_from_deployment_loaded_from_marker(kube):
     """Get the Pods for a Deployment which is loaded via the kubetest
     'applymanifest' marker.
@@ -42,7 +43,7 @@ def test_pods_from_deployment_loaded_in_test_case(kube):
     use that to get the pods for the deployment.
     """
 
-    deployment = kube.load_deployment('manifests/deployment-redis.yaml')
+    deployment = kube.load_deployment(os.path.join(os.path.dirname(__file__), 'manifests/deployment-redis.yaml'))
     deployment.create()
     deployment.wait_until_ready(timeout=30)
 


### PR DESCRIPTION
This PR:
- updates some example tests so that they can be run from a higher-level directory without failing.