### PR TITLE
Add namespace marker

### DIFF
--- a/docs/markers.rst
+++ b/docs/markers.rst
@@ -296,21 +296,26 @@ Summary
 
     @pytest.mark.namespace(create=True, name=None)
 
-``namespace`` helps defining the way namespaces are handled for each test case.
+``namespace`` helps define the way namespaces are handled for each test case.
 
 
 Description
 ~~~~~~~~~~~
 
-Namespace configuration for this test.
-By default a new namespace with a randomized name is created for each test case.
-Set ``create`` to False to not create any namespace.
-Set ``name`` to a string to use give the namespace a specific name, or set to None to generate a unique name.
+The ``namespace`` marker exposes some configuration to control how namespaces are handled
+by kubetest.
 
-Note: When ``create`` is False, the objects created by test test are not automatically deleted
+By default a new namespace with a randomized name is created for each test case.
+Set ``create`` to *False* to not create any namespace.
+Set ``name`` to a string to give the namespace a specific name, or set to *None*
+to use a randomized name.
+
+Note: When ``create`` is *False*, the objects created inside the test and by the 
+applymanifest/applymanifests markers are not automatically deleted.
 
 Examples
 ~~~~~~~~
+
 - Do not create a namespace for a given test
 
   .. code-block:: python
@@ -319,7 +324,8 @@ Examples
       def test_something(kube):
           ...
 
-- Do not create a namespace and create all objects in existing-ns
+- Do not create a namespace and create all objects in the ``existing-ns``
+  namespace
 
   .. code-block:: python
 

--- a/docs/markers.rst
+++ b/docs/markers.rst
@@ -284,3 +284,52 @@ Examples
       def test_something(kube):
           ...
 
+.. _namespace_marker:
+
+Namespace
+------------
+
+Summary
+~~~~~~~
+
+.. code-block:: python
+
+    @pytest.mark.namespace(create=True, name=None)
+
+``namespace`` helps defining the way namespaces are handled for each test case.
+
+
+Description
+~~~~~~~~~~~
+
+Namespace configuration for this test.
+By default a new namespace with a randomized name is created for each test case.
+Set ``create`` to False to not create any namespace.
+Set ``name`` to a string to use give the namespace a specific name, or set to None to generate a unique name.
+
+Examples
+~~~~~~~~
+- Do not create a namespace for a given test
+
+  .. code-block:: python
+
+      @pytest.mark.namespace(create=False)
+      def test_something(kube):
+          ...
+
+- Do not create a namespace and create all objects in existing-ns
+
+  .. code-block:: python
+
+      @pytest.mark.namespace(create=False, name='existing-ns')
+      def test_something(kube):
+          ...
+
+- Create a namespace with a specific name
+
+  .. code-block:: python
+
+      @pytest.namespace(create=True, name='specific-name')
+      def test_something(kube):
+          ...
+

--- a/docs/markers.rst
+++ b/docs/markers.rst
@@ -307,6 +307,8 @@ By default a new namespace with a randomized name is created for each test case.
 Set ``create`` to False to not create any namespace.
 Set ``name`` to a string to use give the namespace a specific name, or set to None to generate a unique name.
 
+Note: When ``create`` is False, the objects created by test test are not automatically deleted
+
 Examples
 ~~~~~~~~
 - Do not create a namespace for a given test

--- a/kubetest/manager.py
+++ b/kubetest/manager.py
@@ -203,8 +203,8 @@ class TestMeta:
             )
             return
 
-        # delete the test case namespace if we've created it. this will also delete anything
-        # in the namespace, which includes RoleBindings.
+        # Delete the test case namespace if we've created it.
+        # This will also delete anything in the namespace, which includes RoleBindings.
         if self._namespace and self.namespace_create:
             self.namespace.delete()
 

--- a/kubetest/manager.py
+++ b/kubetest/manager.py
@@ -125,10 +125,14 @@ class TestMeta:
         node_id (str): The id of the test node.
     """
 
-    def __init__(self, name, node_id):
+    def __init__(self, name, node_id, namespace_create, namespace_name):
         self.name = name
         self.node_id = node_id
-        self.ns = utils.new_namespace(name)
+
+        if namespace_name is None:
+            self.ns = utils.new_namespace(name)
+        else:
+            self.ns = namespace_name
 
         # Flag to designate whether pytest setup (not TestMeta.setup) failed.
         # If pytest setup failed for the case, we can skip teardown, as there
@@ -139,6 +143,7 @@ class TestMeta:
         self._client = None
         self._namespace = None
 
+        self.namespace_create = namespace_create
         self.rolebindings = []
         self.clusterrolebindings = []
 
@@ -165,7 +170,8 @@ class TestMeta:
         ready to use by a test case.
         """
         # create the test case namespace
-        self.namespace.create()
+        if self.namespace_create:
+            self.namespace.create()
 
         # if there are any role bindings, create them.
         for rb in self.rolebindings:
@@ -197,9 +203,9 @@ class TestMeta:
             )
             return
 
-        # delete the test case namespace. this will also delete anything
+        # delete the test case namespace if we've created it. this will also delete anything
         # in the namespace, which includes RoleBindings.
-        if self._namespace:
+        if self._namespace and self.namespace_create:
             self.namespace.delete()
 
         # ClusterRoleBindings are not bound to a namespace, so we will need
@@ -310,7 +316,7 @@ class KubetestManager:
         # is created for the test node.
         self.nodes = {}
 
-    def new_test(self, node_id, test_name):
+    def new_test(self, node_id, test_name, namespace_create, namespace_name):
         """Create a new TestMeta for a test case.
 
         This will be called by the test setup hook in order to create a new
@@ -327,7 +333,10 @@ class KubetestManager:
         meta = TestMeta(
             node_id=node_id,
             name=test_name,
+            namespace_create=namespace_create,
+            namespace_name=namespace_name
         )
+
         self.nodes[node_id] = meta
         return meta
 

--- a/kubetest/markers.py
+++ b/kubetest/markers.py
@@ -61,6 +61,15 @@ ROLEBINDING_INI = (
 )
 
 
+NAMESPACE_INI = (
+    'namespace(create=True, name=None): '
+    'Namespace configuration for this test. '
+    'By default a new namespace with a randomized name is created for each test case. '
+    'Set create to False to not create a namespace at all. '
+    'Set name to a string to create a namespace with a given name.'
+)
+
+
 def register(config):
     """Register kubetest markers with pytest.
 
@@ -71,6 +80,7 @@ def register(config):
     config.addinivalue_line('markers', APPLYMANIFESTS_INI)
     config.addinivalue_line('markers', CLUSTERROLEBINDING_INI)
     config.addinivalue_line('markers', ROLEBINDING_INI)
+    config.addinivalue_line('markers', NAMESPACE_INI)
 
 
 def apply_manifest_from_marker(item, client):

--- a/kubetest/plugin.py
+++ b/kubetest/plugin.py
@@ -216,10 +216,18 @@ def pytest_runtest_setup(item):
     # there should NOT be any gating around test case metadata creation since
     # it is too early to tell whether we have all of the info we need.
 
+    namespace_create = True
+    namespace_name = None
+    for mark in item.iter_markers(name="namespace"):
+        namespace_create = mark.kwargs.get('create', True)
+        namespace_name = mark.kwargs.get('name', None)
+
     # Register a new test case with the manager and setup the test case state.
     test_case = manager.new_test(
         node_id=item.nodeid,
         test_name=item.name,
+        namespace_create=namespace_create,
+        namespace_name=namespace_name,
     )
 
     # Note: These markers are not applied right now, meaning that the resource(s)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -9,7 +9,7 @@ def test_manager_new_test():
     m = manager.KubetestManager()
     assert len(m.nodes) == 0
 
-    c = m.new_test('node-id', 'test-name')
+    c = m.new_test('node-id', 'test-name', True, None)
     assert isinstance(c, manager.TestMeta)
     assert 'kubetest-test-name-' in c.ns
 
@@ -17,11 +17,32 @@ def test_manager_new_test():
     assert 'node-id' in m.nodes
 
 
+def test_manager_new_test_with_ns_name():
+    """Test creating a new TestMeta with a given namespace name
+       from the manager."""
+
+    m = manager.KubetestManager()
+    c = m.new_test('node-id', 'test-name', True, 'my-test')
+    assert isinstance(c, manager.TestMeta)
+    assert c.ns == 'my-test'
+    assert c.namespace_create is True
+
+
+def test_manager_new_test_without_ns():
+    """Test creating a new TestMeta without namespace creation
+       from the manager."""
+
+    m = manager.KubetestManager()
+    c = m.new_test('node-id', 'test-name', False, None)
+    assert isinstance(c, manager.TestMeta)
+    assert c.namespace_create is False
+
+
 def test_manager_get_test():
     """Test getting an existing TestMeta from the manager."""
 
     m = manager.KubetestManager()
-    m.nodes['foobar'] = manager.TestMeta('foo', 'bar')
+    m.nodes['foobar'] = manager.TestMeta('foo', 'bar', True, None)
 
     c = m.get_test('foobar')
     assert isinstance(c, manager.TestMeta)


### PR DESCRIPTION
This adds a pytest.mark.namespace marker to control the way namespaces are managed for each test case. Current options are:

* `create`: Whether to create or not the namespace automatically (default: True)
* `name`: Name of the namespace, or autogenerated if None (default: None)

Use cases:

* Users may not have permission to create namespaces, which causes the tests to fail even if the namespace is not needed (we commonly deploy a workload and want to run tests against it, this doesn't require creating any resources)

* Some tests can only be run in given existing namespaces (for example a namespace with service mesh enabled, or with an existing configmap/secret...)