### PR TITLE
run test teardown when kubeconfig is specified via fixture

### DIFF
--- a/kubetest/__init__.py
+++ b/kubetest/__init__.py
@@ -1,7 +1,7 @@
 """kubetest -- a Kubernetes integration test framework in Python."""
 
 __title__ = 'kubetest'
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 __description__ = 'A Kubernetes integration test framework in Python.'
 __author__ = 'Vapor IO'
 __author_email__ = 'vapor@vapor.io'

--- a/regression/154/README.md
+++ b/regression/154/README.md
@@ -1,0 +1,42 @@
+
+https://github.com/vapor-ware/kubetest/issues/154
+
+### Summary
+
+When the kubeconfig is provided by a pytest fixture and not via the `--kube-config` command line
+flag, the kubetest test manager does not run its teardown functionality due to an explicit
+check for the `--kube-config` flag, which is a remnant from before the introduction of the
+`kubeconfig` fixture.
+
+```python
+if item.config.getoption('kube_config'):
+    manager.teardown(item.nodeid)
+```
+
+#### Expectations
+
+When run with a fixture-defined kubeconfig, the test should run (and pass) and the
+test namespace should be cleaned up afterwards.
+
+```console
+$ pytest -s .
+============================= test session starts =============================
+platform darwin -- Python 3.6.7, pytest-4.4.0, py-1.8.0, pluggy-0.9.0
+kubetest config file: default
+kubetest context: current context
+rootdir: /Users/edaniszewski/dev/vaporio/kubetest
+plugins: requests-mock-1.6.0, grpc-0.7.0, asyncio-0.10.0, kubetest-0.5.0
+collected 1 item                                                              
+
+test_154.py .
+
+========================== 1 passed in 0.07 seconds ===========================
+$
+$ kubectl get ns
+NAME                                 STATUS   AGE
+default                              Active   36m
+docker                               Active   35m
+kube-node-lease                      Active   36m
+kube-public                          Active   36m
+kube-system                          Active   36m
+```

--- a/regression/154/test_154.py
+++ b/regression/154/test_154.py
@@ -1,0 +1,11 @@
+
+import pytest
+
+
+@pytest.fixture
+def kubeconfig(request):
+    return '~/.kube/config'
+
+
+def test_154(kube):
+    kube.wait_for_ready_nodes(1, timeout=3 * 60)


### PR DESCRIPTION
This PR:
- adds a check during test teardown to see whether the kubeconfig fixture has been specified
- preemptively bumps version to 0.5.1

fixes #154 (@lfn3)