### PR TITLE
bugfix: use kubeconfig fixture to get config for clusterinfo

### DIFF
--- a/kubetest/plugin.py
+++ b/kubetest/plugin.py
@@ -386,7 +386,7 @@ class ClusterInfo:
 
 
 @pytest.fixture
-def clusterinfo(request):
+def clusterinfo(kubeconfig):
     """Get a ``ClusterInfo`` instance which provides basic information
     about the cluster the tests are being run on.
     """
@@ -398,7 +398,7 @@ def clusterinfo(request):
     # Get the current context.
     _, current = kubernetes.config.list_kube_config_contexts(
         os.path.expandvars(os.path.expanduser(
-            request.session.config.getoption('kube_config')
+            kubeconfig,
         ))
     )
 

--- a/regression/156-bl/README.md
+++ b/regression/156-bl/README.md
@@ -1,0 +1,13 @@
+
+https://github.com/vapor-ware/kubetest/issues/156
+
+### Summary
+
+This is a baseline (bl) test case for issue #156. It verifies that the `clusterinfo` fixture
+will use the value specified by the `--kube-config` command line arg when specified. See
+[regression/156](../156) for more details.
+
+#### Expectations
+
+When run with a command-line defined kubeconfig, a test using the `clusterinfo` fixture should
+resolve the cluster info using the kubeconfig specified by the command line flag.

--- a/regression/156-bl/test_156.py
+++ b/regression/156-bl/test_156.py
@@ -1,0 +1,5 @@
+
+
+def test_156_baseline(kube, clusterinfo):
+    kube.wait_for_ready_nodes(1, timeout=3 * 60)
+    print(f'cluster info: {vars(clusterinfo)}')

--- a/regression/156/README.md
+++ b/regression/156/README.md
@@ -1,0 +1,13 @@
+
+https://github.com/vapor-ware/kubetest/issues/156
+
+### Summary
+
+When the kubeconfig is provided by a pytest fixture and not via the `--kube-config` command line
+flag, the `clusterinfo` fixture will fail, since it uses the kubeconfig value specified by the
+command line flag and does not account for custom fixture.
+
+#### Expectations
+
+When run with a fixture-defined kubeconfig, a test using the `clusterinfo` fixture should
+resolve the cluster info using the kubeconfig provided by the custom fixture.

--- a/regression/156/test_156.py
+++ b/regression/156/test_156.py
@@ -1,0 +1,12 @@
+
+import pytest
+
+
+@pytest.fixture
+def kubeconfig(request):
+    return '~/.kube/config'
+
+
+def test_156(kube, clusterinfo):
+    kube.wait_for_ready_nodes(1, timeout=3 * 60)
+    print(f'cluster info: {vars(clusterinfo)}')


### PR DESCRIPTION
This PR:
- gets the kubeconfig from the `kubeconfig` fixture rather than command line args when collecting info for the cluster. this allows a custom kubconfig to be defined and be picked up automatically.
- adds regression tests for the case.

fixes #156