### PR TITLE
Add Requests to Services

### DIFF
--- a/examples/get-all-pods-via-fixture/test_examples.py
+++ b/examples/get-all-pods-via-fixture/test_examples.py
@@ -4,7 +4,8 @@ import time
 import os
 
 
-@pytest.mark.applymanifest(os.path.join(os.path.dirname(__file__), 'manifests/deployment-redis.yaml'))
+@pytest.mark.applymanifest(os.path.join(os.path.dirname(__file__),
+                           'manifests/deployment-redis.yaml'))
 def test_pods_from_deployment_loaded_from_marker(kube):
     """Get the Pods for a Deployment which is loaded via the kubetest
     'applymanifest' marker.

--- a/examples/test_deployment.py
+++ b/examples/test_deployment.py
@@ -2,8 +2,6 @@
 
 import os
 
-import time
-
 
 def test_deployment(kube):
 

--- a/kubetest/__init__.py
+++ b/kubetest/__init__.py
@@ -1,7 +1,7 @@
 """kubetest -- a Kubernetes integration test framework in Python."""
 
 __title__ = 'kubetest'
-__version__ = '0.6.4'
+__version__ = '0.6.3'
 __description__ = 'A Kubernetes integration test framework in Python.'
 __author__ = 'Vapor IO'
 __author_email__ = 'vapor@vapor.io'

--- a/kubetest/__init__.py
+++ b/kubetest/__init__.py
@@ -1,7 +1,7 @@
 """kubetest -- a Kubernetes integration test framework in Python."""
 
 __title__ = 'kubetest'
-__version__ = '0.6.2'
+__version__ = '0.6.4'
 __description__ = 'A Kubernetes integration test framework in Python.'
 __author__ = 'Vapor IO'
 __author_email__ = 'vapor@vapor.io'

--- a/kubetest/objects/service.py
+++ b/kubetest/objects/service.py
@@ -179,8 +179,32 @@ class Service(ApiObject):
         Returns:
             The response data
         """
-        return client.CoreV1Api().connect_get_namespaced_service_proxy_with_path(
-            name=f'{self.name}:{self.obj.spec.ports[0].port}',
-            namespace=self.namespace,
-            path=path,
+        path_params = {
+            "name": f'{self.name}:{self.obj.spec.ports[0].port}',
+            "namespace": self.namespace,
+            "path": path
+        }
+        return client.CoreV1Api().api_client.call_api(
+            '/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}', 'GET',
+            path_params=path_params,
+        )
+
+    def proxy_http_post(self, path: str, body) -> str:
+        """Issue a POST request to proxy of a Service.
+
+        Args:
+            path: The URI path for the request.
+
+        Returns:
+            The response data
+        """
+        path_params = {
+            "name": f'{self.name}:{self.obj.spec.ports[0].port}',
+            "namespace": self.namespace,
+            "path": path
+        }
+        return client.CoreV1Api().api_client.call_api(
+            '/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}', 'POST',
+            path_params=path_params,
+            body=body
         )

--- a/kubetest/objects/service.py
+++ b/kubetest/objects/service.py
@@ -176,6 +176,7 @@ class Service(ApiObject):
         Args:
             method: The http request method e.g. 'GET', 'POST' etc.
             path: The URI path for the request.
+            kwargs: Keyword arguments for the proxy_http_get function.
 
         Returns:
             The response data
@@ -198,6 +199,7 @@ class Service(ApiObject):
         Args:
             path: The URI path for the request.
             kwargs: Keyword arguments for the proxy_http_get function.
+
         Returns:
             The response data
         """

--- a/kubetest/objects/service.py
+++ b/kubetest/objects/service.py
@@ -170,41 +170,47 @@ class Service(ApiObject):
         log.debug(f'endpoints: {svc_endpoints}')
         return svc_endpoints
 
-    def proxy_http_get(self, path: str) -> str:
+    def _proxy_http_request(self, method, path, **kwargs) -> tuple:
+        """Template request to proxy of a Service.
+
+        Args:
+            method: The http request method e.g. 'GET', 'POST' etc.
+            path: The URI path for the request.
+
+        Returns:
+            The response data
+        """
+        path_params = {
+            "name": f'{self.name}:{self.obj.spec.ports[0].port}',
+            "namespace": self.namespace,
+            "path": path
+        }
+        return client.CoreV1Api().api_client.call_api(
+            '/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}',
+            method,
+            path_params=path_params,
+            **kwargs
+        )
+
+    def proxy_http_get(self, path: str, **kwargs) -> tuple:
         """Issue a GET request to proxy of a Service.
 
         Args:
             path: The URI path for the request.
-
+            kwargs: Keyword arguments for the proxy_http_get function.
         Returns:
             The response data
         """
-        path_params = {
-            "name": f'{self.name}:{self.obj.spec.ports[0].port}',
-            "namespace": self.namespace,
-            "path": path
-        }
-        return client.CoreV1Api().api_client.call_api(
-            '/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}', 'GET',
-            path_params=path_params,
-        )
+        return self._proxy_http_request('GET', path, **kwargs)
 
-    def proxy_http_post(self, path: str, body) -> str:
+    def proxy_http_post(self, path: str, **kwargs) -> tuple:
         """Issue a POST request to proxy of a Service.
 
         Args:
             path: The URI path for the request.
+            kwargs: Keyword arguments for the proxy_http_post function.
 
         Returns:
             The response data
         """
-        path_params = {
-            "name": f'{self.name}:{self.obj.spec.ports[0].port}',
-            "namespace": self.namespace,
-            "path": path
-        }
-        return client.CoreV1Api().api_client.call_api(
-            '/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}', 'POST',
-            path_params=path_params,
-            body=body
-        )
+        return self._proxy_http_request('POST', path, **kwargs)


### PR DESCRIPTION
### Tasks
- [x] add post request to services
- [x] modify get request in services for consistency

### Comments
- `connect_post_namespaced_service_proxy_with_path` does not allow for the body of a request, which is weird. So I've bypassed it to utilize `call_api` and thus modified the existing `proxy_http_get` service method for consistency. Let me know if you would rather the original `proxy_http_get`, it is more direct however I do prefer consistency.
- version is updated to `0.6.4` as I'm hoping `Add Ingress Type` i.e. version `0.6.3` can be reviewed and merged it as well.

