### PR TITLE
bugfix: use the correct api client for getting Ingresses

### DIFF
--- a/examples/configs/ingress.yaml
+++ b/examples/configs/ingress.yaml
@@ -1,0 +1,13 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: my-ingress
+spec:
+  rules:
+    - host:
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: my-service
+            servicePort: 80

--- a/examples/test_ingress.py
+++ b/examples/test_ingress.py
@@ -1,0 +1,26 @@
+"""An example of using kubetest to manage an ingress."""
+
+import os
+
+
+def test_ingress(kube):
+
+    f = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        'configs',
+        'ingress.yaml'
+    )
+
+    ing = kube.load_ingress(f)
+
+    kube.create(ing)
+
+    ing.wait_until_ready(timeout=20)
+    ing.refresh()
+
+    ings = kube.get_ingresses()
+    assert len(ings) == 1
+
+    kube.delete(ing)
+
+    ing.wait_until_deleted(timeout=20)

--- a/kubetest/client.py
+++ b/kubetest/client.py
@@ -854,7 +854,7 @@ class TestClient:
 
         selectors = utils.selector_kwargs(fields, labels)
 
-        ingress_list = client.CoreV1Api().\
+        ingress_list = client.ExtensionsV1beta1Api().\
             list_namespaced_ingress(
             namespace=namespace,
             **selectors,


### PR DESCRIPTION
This PR:
- fixes a bug where the incorrect client was being used for getting ingresses.

fixes #179