### PR TITLE
Allow for environment variable "KUBECONFIG"

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -41,6 +41,7 @@ kubernetes integration test support:
 - ``--kube-config <PATH>``
 
     Specifies the path to the config file to use for connecting to your cluster.
+    Alternatively, you can set the KUBECONFIG env var, and then you will not need to specify.
     If this option is not specified, ``kubetest`` will not install resources onto
     the cluster, which may cause test failure.
 

--- a/kubetest/plugin.py
+++ b/kubetest/plugin.py
@@ -437,6 +437,7 @@ def kube(kubeconfig, request) -> TestClient:
     if request.session.config.getoption('in_cluster'):
         kubernetes.config.load_incluster_config()
     else:
+        kubeconfig = kubeconfig or os.getenv("KUBECONFIG")
         if kubeconfig:
             kubernetes.config.load_kube_config(
                 config_file=os.path.expandvars(os.path.expanduser(kubeconfig)),
@@ -445,8 +446,8 @@ def kube(kubeconfig, request) -> TestClient:
         else:
             log.error(
                 'unable to interact with cluster: kube fixture used without kube config '
-                'set. the config may be set with the --kube-config or --in-cluster flags '
-                'or by defining a custom kubeconfig fixture.'
+                'set. the config may be set with the flags --kube-config or --in-cluster or by'
+                'an env var KUBECONFIG or custom kubeconfig fixture definition.'
             )
             raise errors.SetupError('no kube config defined for test run')
 


### PR DESCRIPTION
in my pytest configuration I am generating the kubeconfig with boto, and so instead of creating it prior, i am generating it on setup_function, and then setting the kubeconfig env appropriately.