### PR TITLE
Introduce Manifest Templates

### DIFF
--- a/kubetest/manifest.py
+++ b/kubetest/manifest.py
@@ -11,7 +11,6 @@ import kubernetes
 import yaml
 from kubernetes.client import models
 
-
 # Callable type describing the signature of render() implementations
 Renderer = Callable[[Union[str, TextIO], Dict[str, Any]], Union[str, TextIO]]
 __render__: Optional[Renderer] = None
@@ -19,16 +18,16 @@ __render__: Optional[Renderer] = None
 
 def render(template: Union[str, TextIO], context: Dict[str, Any]) -> Union[str, TextIO]:
     """Render a manifest template into a YAML document using the module render callable.
-    
+
     Rendering is performed by the module global `__render__` callable.
     The default implementation returns the input template unmodified.
     To implement a different default rendering behavior, set the `__render__`
     attribute to a `RenderCallable` object.
-    
+
     Args:
         template: Then template to render.
         context: A dictionary of variables available to the template.
-    
+
     Returns:
         The rendered content of the manifest template.
     """
@@ -46,7 +45,7 @@ class ContextRenderer:
     arbitrary number of rendering operations. They are useful in accumulating
     context state during test setup when manifest templates need access to state
     that was established earlier.
-    
+
     Args:
         renderer: A callable that renders a templated manifest. Defaults to the
             module local `render` function which renders using the `__render__`
@@ -54,28 +53,28 @@ class ContextRenderer:
         context: A dictionary of runtime values available to the template during
             rendering. Defaults to an empty dictionary.
     """
-    
+
     def __init__(self, renderer: Renderer = render, context: Dict[str, Any] = {}) -> None:
         self._renderer = renderer
         self._context = context
-    
+
     @property
     def context(self) -> Dict[str, Any]:
         """The context variables set on the renderer."""
         return self._context
-    
+
     def __call__(self, template: Union[str, TextIO], context: Dict[str, Any]) -> Union[str, TextIO]:
         """Render a manifest template file to a YAML docoment.
-        
+
         Args:
             template: The template to render.
             context: A dictionary of template variables available for use during
                 rendering.
-        
+
         Returns:
             The rendered content of the manifest template.
         """
-        merged_context = { **self.context, **context }
+        merged_context = {**self.context, **context}
         return self._renderer(template, merged_context)
 
 
@@ -128,7 +127,8 @@ def load_path(path: str, *, renderer: Renderer = render) -> List[object]:
         raise ValueError(f'{path} is not a directory')
 
     objs = []
-    if isinstance(renderer, ContextRenderer): renderer.context["objs"] = objs
+    if isinstance(renderer, ContextRenderer):
+        renderer.context["objs"] = objs
     for f in os.listdir(path):
         if os.path.splitext(f)[1].lower() in ['.yaml', '.yml']:
             objs = objs + load_file(os.path.join(path, f), renderer=renderer)

--- a/kubetest/markers.py
+++ b/kubetest/markers.py
@@ -36,7 +36,7 @@ APPLYMANIFESTS_INI = (
 )
 
 RENDER_MANIFESTS_INI = (
-    'render_manifests_with(render, context={}): '
+    'render_manifests.with_args(render, context={}): '
     'set a callable for rendering manifest templates. '
     'The render argument must be a callable that accepts a template file or string'
     'value and returns a rendered YAML document that can be applied to Kubernetes.'
@@ -102,7 +102,7 @@ def get_manifest_render_for_item(item: pytest.Item) -> RenderCallable:
     """Return the callable for rendering a manifest template.
     
     Returns a custom render implementation set via the closest
-    `pytest.mark.render_manifests_with` marker or the `kubetest.manifest.default_render`
+    `pytest.mark.render_manifests` marker or the `kubetest.manifest.default_render`
     default implementation if no marker is found.
     
     Args:
@@ -111,7 +111,7 @@ def get_manifest_render_for_item(item: pytest.Item) -> RenderCallable:
     Returns:
         A callable for rendering manifest templates into YAML documents.
     """
-    mark = item.get_closest_marker("render_manifests_with")
+    mark = item.get_closest_marker("render_manifests")
     return mark.args[0] if mark else default_render
 
 def apply_manifest_from_marker(item: pytest.Item, meta: manager.TestMeta) -> None:

--- a/kubetest/markers.py
+++ b/kubetest/markers.py
@@ -36,7 +36,7 @@ APPLYMANIFESTS_INI = (
 )
 
 RENDER_MANIFESTS_INI = (
-    'render_manifests.with_args(render, context={}): '
+    'render_manifests(render, context={}): '
     'set a callable for rendering manifest templates. '
     'The render argument must be a callable that accepts a template file or string'
     'value and returns a rendered YAML document that can be applied to Kubernetes.'

--- a/kubetest/markers.py
+++ b/kubetest/markers.py
@@ -1,17 +1,18 @@
 """Custom pytest markers for kubetest."""
 
 import os
-from typing import List
+from typing import Any, Dict, List, TextIO, Union
 
 import pytest
 from kubernetes import client
 
 from kubetest import manager
-from kubetest.manifest import load_file, load_path
+from kubetest.manifest import RenderCallable, Renderer, default_render, load_file, load_path
 from kubetest.objects import ApiObject, ClusterRoleBinding, RoleBinding
 
+
 APPLYMANIFEST_INI = (
-    'applymanifest(path): '
+    'applymanifest(path, render=None): '
     'load a YAML manifest file from the specified path and create it on the cluster. '
     'This marker is similar to the "kubectl apply -f <path>" command. Loading a '
     'manifest via this marker will not prohibit you from loading other manifests '
@@ -22,7 +23,7 @@ APPLYMANIFEST_INI = (
 )
 
 APPLYMANIFESTS_INI = (
-    'applymanifests(dir, files=None): '
+    'applymanifests(dir, files=None, render=None): '
     'load YAML manifests from the specified path and create them on the cluster. '
     'By default, all YAML files found in the specified path will be loaded and created. '
     'If a list is passed to the files parameter, only the files in the path matching '
@@ -32,6 +33,15 @@ APPLYMANIFESTS_INI = (
     'references to the created objects. Manifests loaded via this marker are registered '
     'with the internal test case metainfo and can be waited upon for creation via the '
     '"kube" fixture\'s "wait_until_created" method.'
+)
+
+RENDER_MANIFESTS_INI = (
+    'render_manifests_with(render, context={}): '
+    'set a callable for rendering manifest templates. '
+    'The render argument must be a callable that accepts a template file or string'
+    'value and returns a rendered YAML document that can be applied to Kubernetes.'
+    'The optional context argument can be used to set template variables that are made'
+    'available to the template at render time.'
 )
 
 CLUSTERROLEBINDING_INI = (
@@ -83,13 +93,29 @@ def register(config) -> None:
     """
     config.addinivalue_line('markers', APPLYMANIFEST_INI)
     config.addinivalue_line('markers', APPLYMANIFESTS_INI)
+    config.addinivalue_line('markers', RENDER_MANIFESTS_INI)
     config.addinivalue_line('markers', CLUSTERROLEBINDING_INI)
     config.addinivalue_line('markers', ROLEBINDING_INI)
     config.addinivalue_line('markers', NAMESPACE_INI)
 
+def get_manifest_render_for_item(item: pytest.Item) -> RenderCallable:
+    """Return the callable for rendering a manifest template.
+    
+    Returns a custom render implementation set via the closest
+    `pytest.mark.render_manifests_with` marker or the `kubetest.manifest.default_render`
+    default implementation if no marker is found.
+    
+    Args:
+        item: The pytest test item.
+    
+    Returns:
+        A callable for rendering manifest templates into YAML documents.
+    """
+    mark = item.get_closest_marker("render_manifests_with")
+    return mark.args[0] if mark else default_render
 
 def apply_manifest_from_marker(item: pytest.Item, meta: manager.TestMeta) -> None:
-    """Load a manifest and create the API objects for teh specified file.
+    """Load a manifest and create the API objects for the specified file.
 
     This gets called for every `pytest.mark.applymanifest` marker on
     test cases.
@@ -101,16 +127,22 @@ def apply_manifest_from_marker(item: pytest.Item, meta: manager.TestMeta) -> Non
     Args:
         item: The pytest test item.
         meta: The metainfo object for the marked test case.
-    """
+    """    
+    item_render = get_manifest_render_for_item(item)
     for mark in item.iter_markers(name='applymanifest'):
         path = mark.args[0]
+        render = mark.kwargs.get('render', item_render)
+        if not callable(render):
+            raise TypeError(f"renderer given is not callable")        
 
         # Normalize the path to be absolute.
         if not os.path.isabs(path):
             path = os.path.abspath(path)
 
         # Load the manifest
-        objs = load_file(path)
+        context = dict(namespace=meta.ns, test_node_id=meta.node_id, test_name=meta.name)
+        renderer = Renderer(render, context)
+        objs = load_file(path, renderer=renderer)
 
         # For each of the loaded Kubernetes resources, wrap it in the
         # equivalent kubetest wrapper. If the object does not yet have a
@@ -145,9 +177,14 @@ def apply_manifests_from_marker(item: pytest.Item, meta: manager.TestMeta) -> No
         item: The pytest test item.
         meta: The metainfo object for the marked test case.
     """
+    item_render = get_manifest_render_for_item(item)
     for mark in item.iter_markers(name='applymanifests'):
         dir_path = mark.args[0]
         files = mark.kwargs.get('files')
+        render = mark.kwargs.get('render', item_render)
+        
+        if not callable(render):
+            raise TypeError(f"renderer given is not callable")        
 
         # We expect the path specified to either be absolute or relative
         # from the test file. If the path is relative, add the directory
@@ -156,15 +193,20 @@ def apply_manifests_from_marker(item: pytest.Item, meta: manager.TestMeta) -> No
             dir_path = os.path.abspath(
                 os.path.join(os.path.dirname(item.fspath), dir_path)
             )
+        
+        # Setup template rendering context
+        context = dict(dir_path=dir_path, namespace=meta.ns, test_node_id=meta.node_id, test_name=meta.name)
+        renderer = Renderer(render, context)
 
         # If there are any files specified, we will only load those files.
         # Otherwise, we'll load everything in the directory.
         if files is None:
-            objs = load_path(dir_path)
+            objs = load_path(dir_path, renderer=renderer)
         else:
             objs = []
+            renderer.context["objs"] = objs
             for f in files:
-                objs.extend(load_file(os.path.join(dir_path, f)))
+                objs.extend(load_file(os.path.join(dir_path, f), renderer=renderer))
 
         # For each of the loaded Kubernetes resources, we'll want to wrap it
         # in the equivalent kubetest wrapper. If the resource does not have


### PR DESCRIPTION
This is still a work in progress but figured I would go ahead and start the dialogue.

This PR introduces the ability to preprocess manifests and render them as templates before they are applied to the cluster. It allows an easy path for getting runtime values into the YAML.

My specific use-case is that I am doing some testing for components that are heavily dependent on Prometheus and Envoy and there are values that I need to get into the configuration. Prometheus is configured off a config map and I need to get the testing namespace and some other odds and ends in there. Editing the resources after creation is cumbersome and slow with the intermediate representations and then services have to be restarted and awaited. I also looked at intercepting the object representations before they are dispatched to the API, but this felt higher value -- I may wind up adding that later.

Anyway, I digress. Quick details on the PR:

1. The `applymanifest` and `applymanifests` markers pick up a new `render` keyword argument. This is a callable that takes a TextIO or str, a dictionary of context values, and returns a new fully resolved YAMLdoc.
2. There's a new marker `render_manifests.with_args(render, context={})` marker for configuring a default renderer at whatever scope.
3. The `kubetest.manifest` module has been updated to be renderer aware.
4. The default implementation just returns the manifest unmodified -- I didn't add any dependencies. You have to hook it with a render implementation. I am using [Chevrom](https://github.com/noahmorrison/chevron/) to get simple mustache logicless templates. Jinja2 and such will work easily also.
5. It enables some other interesting use tricks like generating the YAML from a different representation + runtime state, getting secrets into the manifests, etc.

Cheers.