### PR TITLE
Read KUBECONFIG environment variable globally instead of only in kube fixture

### DIFF
--- a/kubetest/plugin.py
+++ b/kubetest/plugin.py
@@ -44,7 +44,7 @@ def pytest_addoption(parser):
         '--kube-config',
         action='store',
         metavar='path',
-        default=None,
+        default=os.getenv("KUBECONFIG"),
         help=(
             'the kubernetes config for kubetest; this is required for '
             'resources to be installed on the cluster'
@@ -427,7 +427,7 @@ def clusterinfo(kubeconfig) -> ClusterInfo:
 def kubeconfig(request) -> Optional[str]:
     """Return the name of the configured kube config file loaded for the tests."""
 
-    config_file = request.session.config.getoption('kube_config') or os.getenv("KUBECONFIG")
+    config_file = request.session.config.getoption('kube_config')
     return config_file
 
 

--- a/kubetest/plugin.py
+++ b/kubetest/plugin.py
@@ -427,7 +427,7 @@ def clusterinfo(kubeconfig) -> ClusterInfo:
 def kubeconfig(request) -> Optional[str]:
     """Return the name of the configured kube config file loaded for the tests."""
 
-    config_file = request.session.config.getoption('kube_config')
+    config_file = request.session.config.getoption('kube_config') or os.getenv("KUBECONFIG")
     return config_file
 
 
@@ -449,7 +449,6 @@ def kube(kubeconfig, kubecontext, request) -> TestClient:
     if request.session.config.getoption('in_cluster'):
         kubernetes.config.load_incluster_config()
     else:
-        kubeconfig = kubeconfig or os.getenv("KUBECONFIG")
         if kubeconfig:
             kubernetes.config.load_kube_config(
                 config_file=os.path.expandvars(os.path.expanduser(kubeconfig)),


### PR DESCRIPTION
This change should resolve https://github.com/vapor-ware/kubetest/issues/205 by referencing the KUBECONFIG environment variable whenever `kubeconfig` is injected from the fixture, rather than only reading it when `kubeconfig` is None in the `kube` fixture.

I tested that this resolves my local issue, and the unit tests all pass after making the change.