### PR TITLE
Fix TestClient unable to get replicasets

### DIFF
--- a/kubetest/client.py
+++ b/kubetest/client.py
@@ -972,7 +972,7 @@ class TestClient:
         replicasets = {}
         for obj in results.items:
             rs = objects.ReplicaSet(obj)
-            replicasets[replicasets.name] = rs
+            replicasets[rs.name] = rs
 
         return replicasets
 

--- a/kubetest/objects/replicaset.py
+++ b/kubetest/objects/replicaset.py
@@ -39,8 +39,6 @@ class ReplicaSet(ApiObject):
         super(ReplicaSet, self).__init__(*args, **kwargs)
         self._add_kubetest_labels()
 
-        client.AppsV1Api.read_namespaced_replica_set()
-
     def _add_kubetest_labels(self) -> None:
         """Add a kubetest label to the ReplicaSet object.
 


### PR DESCRIPTION
Fixes #213 

- Use name prop from rs object instead of results dict
- Remove read_namespaced_replica_set call with no assignment or args